### PR TITLE
Changes on package.json to reflect repository location change

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "redux-thunk": "^2.2.0",
     "topojson-client": "^3.0.0",
     "velocity-react": "^1.3.3",
-    "whatwg-fetch": "^2.0.3"
+    "whatwg-fetch": "^2.0.3",
+    "globalfishingwatch-convert": "git+https://github.com/GlobalFishingWatch/map-convert.git"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Vizzuality/GlobalFishingWatch.git"
+    "url": "git+https://github.com/GlobalFishingWatch/map-client.git"
   },
   "keywords": [
     "visualisation"
@@ -22,9 +22,9 @@
   "author": "Vizzuality <hello@vizzuality.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Vizzuality/GlobalFishingWatch/issues"
+    "url": "https://github.com/GlobalFishingWatch/map-client/issues"
   },
-  "homepage": "https://github.com/Vizzuality/GlobalFishingWatch#readme",
+  "homepage": "https://github.com/GlobalFishingWatch/map-client#readme",
   "dependencies": {
     "body-parser": "^1.17.2",
     "classnames": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "redux-thunk": "^2.2.0",
     "topojson-client": "^3.0.0",
     "velocity-react": "^1.3.3",
-    "whatwg-fetch": "^2.0.3",
-    "globalfishingwatch-convert": "git+https://github.com/GlobalFishingWatch/map-convert.git"
+    "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",


### PR DESCRIPTION
We have moved the GFW map from the Vizzuality organization to GlobalFishingWatch one. We have also migrated the dependent repositories. This PR takes care of the changes needed in the package.json in order for the project to use the correct paths. 