### PR TITLE
Workspace get override

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,60 @@ To do so:
 #### GA_INNER_TIMELINE_EXTENT_CHANGED
 
 Returns the length of the new inner extent in days.
+
+
+# GET parameters available on the client
+
+#### params
+
+A base64-encoded JSON object that represent values to override the currently displayed workspace. See "Workspace override" section below.
+
+#### paramsPlainText
+
+A plain text JSON object that that represent values to override the currently displayed workspace. See "Workspace override" section below.
+
+#### embedded
+
+A boolean value telling whether the client is in embedded mode (no share, no layers, no menu)
+
+# Workspace Override
+
+As of v1:
+```
+{
+  vessels: [[seriesgroup/uvi0, tilesetId0, series0], ..., [seriesgroup/uviN, tilesetIdN,seriesN]],  // merges with workspace pinned vessels, first vessel of the array is shownVessel, series is an optional argument for each vessel
+  view: [zoom, longitude, latitude], // overrides workspace-set view
+  innerExtent: [start, end], // overrides workspace
+  outerExtent: [start, end] // overrides workspace
+  version: int // the version will tell the client the structure of the params
+}
+```
+
+#### vessels
+
+`[[seriesgroup/uvi0, tilesetId0, series0], ..., [seriesgroup/uviN, tilesetIdN,seriesN]]`
+
+Adds specified vessels to the current workspace pinned vessels (`pinnedVessels`).
+The first vessel provided replaces the current workspace `shownVessel`, if existing.
+
+#### view
+
+`[zoom, longitude, latitude]`
+
+Overrides workspace's `map.center` and `map.zoom`.
+
+#### innerExtent
+
+`[start, end]`
+
+Overrides workspace's `timeline.innerExtent`.
+
+#### outerExtent
+
+`[start, end]`
+
+Overrides workspace's `timeline.outerExtent`.
+
+#### version
+
+Should be `"1"`

--- a/app/src/analytics/analyticsMiddleware.js
+++ b/app/src/analytics/analyticsMiddleware.js
@@ -27,7 +27,7 @@ import { SEARCH_QUERY_MINIMUM_LIMIT, TIMELINE_SPEED_CHANGE } from 'config';
 
 import { FLAGS } from 'app/src/constants';
 import { TOGGLE_VESSEL_PIN, SET_PINNED_VESSEL_HUE } from 'actions/vesselInfo';
-import { SET_WORKSPACE_ID } from 'actions/workspace';
+import { SET_WORKSPACE_ID } from 'workspace/workspaceActions';
 
 const GA_ACTION_WHITELIST = [
   {

--- a/app/src/app/appActions.js
+++ b/app/src/app/appActions.js
@@ -1,0 +1,40 @@
+import { setUrlWorkspaceId, setWorkspaceOverride } from 'workspace/workspaceActions';
+import { getURLParameterByName, getURLPieceByName } from 'lib/getURLParameterByName';
+
+export const SET_IS_EMBEDDED = 'SET_IS_EMBEDDED';
+
+export function init() {
+  return (dispatch) => {
+
+    const workspaceId = getURLParameterByName('workspace') || getURLPieceByName('workspace');
+    if (workspaceId !== undefined) {
+      dispatch(setUrlWorkspaceId(workspaceId));
+    }
+
+    const workspaceOverride = getURLParameterByName('params');
+    const workspaceOverridePlainText = getURLParameterByName('paramsPlainText');
+    if (workspaceOverride !== null || workspaceOverridePlainText !== null) {
+      const workspaceOverrideRawData = (workspaceOverridePlainText !== null)
+        ? decodeURIComponent(workspaceOverridePlainText)
+        : atob(workspaceOverride);
+
+      let workspaceOverrideJSON;
+      try {
+        workspaceOverrideJSON = JSON.parse(workspaceOverrideRawData);
+      } catch (e) {
+        console.warn('malformed workspace override parameter', e);
+      }
+
+      if (workspaceOverrideJSON !== undefined) {
+        dispatch(setWorkspaceOverride(workspaceOverrideJSON));
+      }
+    }
+
+
+    const isEmbedded = getURLParameterByName('embedded') === 'true';
+    dispatch({
+      type: SET_IS_EMBEDDED,
+      payload: isEmbedded
+    });
+  };
+}

--- a/app/src/app/appReducer.js
+++ b/app/src/app/appReducer.js
@@ -1,0 +1,14 @@
+import { SET_IS_EMBEDDED } from './appActions';
+
+const initialState = {
+  isEmbedded: false
+};
+
+export default function (state = initialState, action) {
+  switch (action.type) {
+    case SET_IS_EMBEDDED:
+      return Object.assign({}, state, { isEmbedded: action.payload });
+    default:
+      return state;
+  }
+}

--- a/app/src/components/AuthMap.jsx
+++ b/app/src/components/AuthMap.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import MapContainer from 'containers/MapContainer';
-import { getURLParameterByName, getURLPieceByName } from 'lib/getURLParameterByName';
+import { getURLParameterByName } from 'lib/getURLParameterByName';
 import Header from 'siteNav/containers/Header';
 import ModalContainer from 'containers/ModalContainer';
 
@@ -13,9 +13,7 @@ class AuthMap extends Component {
     const canRedirect = getURLParameterByName('redirect_login');
     // TODO: Move isEmbedded to a prop
     this.state = {
-      canRedirect,
-      workspaceId: getURLParameterByName('workspace') || getURLPieceByName('workspace'),
-      isEmbedded: !!getURLParameterByName('embedded')
+      canRedirect
     };
 
     if (!props.token && canRedirect) {
@@ -24,27 +22,24 @@ class AuthMap extends Component {
   }
 
   render() {
-    const canShareWorkspaces = !this.state.isEmbedded &&
+    const canShareWorkspaces = !this.props.isEmbedded &&
       (this.props.userPermissions !== null && this.props.userPermissions.indexOf('shareWorkspace') !== -1);
 
     return (
       <div className="fullHeightContainer" >
-        <Header isEmbedded={this.state.isEmbedded} canShareWorkspaces={canShareWorkspaces} />
-        <ModalContainer
-          isEmbedded={this.state.isEmbedded}
-        />
+        <Header canShareWorkspaces={canShareWorkspaces} />
+        <ModalContainer canShareWorkspaces={canShareWorkspaces} />
         <MapContainer workspaceId={this.state.workspaceId} isEmbedded={this.state.isEmbedded} />
 
-      </div >);
+      </div>);
   }
 }
 
 AuthMap.propTypes = {
-  canRedirect: PropTypes.bool,
   login: PropTypes.func,
   token: PropTypes.string,
   userPermissions: PropTypes.array,
-  workspaceId: PropTypes.string
+  isEmbedded: PropTypes.bool
 };
 
 export default AuthMap;

--- a/app/src/components/ModalContainer.jsx
+++ b/app/src/components/ModalContainer.jsx
@@ -18,7 +18,7 @@ import SubscriptionModal from 'report/containers/SubscriptionModal';
 
 class ModalContainer extends Component {
   render() {
-    const canShareWorkspaces = !this.props.isEmbedded && (this.props.userPermissions !== null && this.props.userPermissions.indexOf('shareWorkspace') !== -1);
+    const canShareWorkspaces = !this.props.isEmbedded && this.props.canShareWorkspaces === true;
     return (
       <div >
         <Modal
@@ -130,7 +130,8 @@ ModalContainer.propTypes = {
   supportFormModalOpen: PropTypes.bool,
   token: PropTypes.string,
   userPermissions: PropTypes.array,
-  welcomeModalOpen: PropTypes.bool
+  welcomeModalOpen: PropTypes.bool,
+  canShareWorkspaces: PropTypes.bool
 };
 
 export default ModalContainer;

--- a/app/src/containers/AuthMap.js
+++ b/app/src/containers/AuthMap.js
@@ -4,7 +4,8 @@ import { login } from 'user/userActions';
 
 const mapStateToProps = state => ({
   token: state.user.token,
-  userPermissions: state.user.userPermissions
+  userPermissions: state.user.userPermissions,
+  isEmbedded: state.app.isEmbedded
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/src/containers/MapContainer.js
+++ b/app/src/containers/MapContainer.js
@@ -1,7 +1,6 @@
 import { connect } from 'react-redux';
 import MapContainer from 'components/MapContainer';
 import { initGoogleMaps, setZoom, setCenter, setMouseLatLong } from 'actions/map';
-import { setUrlWorkspaceId } from 'actions/workspace';
 import { toggleLayerVisibility } from 'layers/layersActions';
 import { hidePolygonModal } from 'report/reportActions';
 import { loadTimebarChartData } from 'timebar/timebarActions';
@@ -23,15 +22,15 @@ const mapStateToProps = state => ({
   token: state.user.token,
   trackBounds: state.vesselInfo.trackBounds,
   userPermissions: state.user.userPermissions,
-  zoom: state.map.zoom
+  zoom: state.map.zoom,
+  isEmbedded: state.app.isEmbedded
 });
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   initMap: (googleMaps) => {
     dispatch(initGoogleMaps(googleMaps));
   },
   loadInitialState: () => {
-    dispatch(setUrlWorkspaceId(ownProps.workspaceId));
     dispatch(loadTimebarChartData(TIMELINE_OVERALL_START_DATE, TIMELINE_OVERALL_END_DATE));
   },
   toggleLayerVisibility: (layer) => {

--- a/app/src/containers/ModalContainer.js
+++ b/app/src/containers/ModalContainer.js
@@ -24,7 +24,8 @@ const mapStateToProps = state => ({
   supportFormModalOpen: state.supportForm.open,
   token: state.user.token,
   userPermissions: state.user.userPermissions,
-  welcomeModalOpen: state.welcomeModal.open
+  welcomeModalOpen: state.welcomeModal.open,
+  isEmbedded: state.app.isEmbedded
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/src/index.jsx
+++ b/app/src/index.jsx
@@ -30,6 +30,8 @@ import shareReducer from 'share/shareReducer';
 import tracksReducer from 'tracks/tracksReducer';
 import AppContainer from 'containers/App';
 import AuthMapContainer from 'containers/AuthMap';
+import { init } from './app/appActions';
+import appReducer from './app/appReducer';
 
 // Polyfill for older browsers (IE11 for example)
 window.Promise = window.Promise || Promise;
@@ -60,7 +62,8 @@ const reducer = combineReducers({
   user: userReducer,
   vesselInfo: vesselInfoReducer,
   encounters: encountersReducer,
-  tracks: tracksReducer
+  tracks: tracksReducer,
+  app: appReducer
 });
 
 /**
@@ -75,9 +78,12 @@ const store = createStore(
 
 render(
   <Provider store={store} >
-    <AppContainer >
+    <AppContainer>
       <AuthMapContainer />
-    </AppContainer >
-  </Provider >,
+    </AppContainer>
+  </Provider>,
   document.getElementById('app')
 );
+
+
+store.dispatch(init());

--- a/app/src/layers/layerLibraryActions.js
+++ b/app/src/layers/layerLibraryActions.js
@@ -1,5 +1,5 @@
 import { DEFAULT_TRACK_HUE } from 'config';
-import { getWorkspace } from 'actions/workspace';
+import { getWorkspace } from 'workspace/workspaceActions';
 import { hexToHue } from 'util/colors';
 import calculateLayerId from 'util/calculateLayerId';
 import { toggleLayerVisibility, toggleLayerWorkspacePresence } from 'layers/layersActions';

--- a/app/src/mapPanels/leftControlPanel/containers/LeftControlPanel.js
+++ b/app/src/mapPanels/leftControlPanel/containers/LeftControlPanel.js
@@ -2,7 +2,7 @@ import { connect } from 'react-redux';
 import { setZoom } from 'actions/map';
 import LeftControlPanel from 'mapPanels/leftControlPanel/components/LeftControlPanel';
 import { openShareModal, setShareModalError } from 'share/shareActions';
-import { saveWorkspace } from 'actions/workspace';
+import { saveWorkspace } from 'workspace/workspaceActions';
 import { setSupportModalVisibility } from 'siteNav/supportFormActions';
 
 const mapStateToProps = state => ({

--- a/app/src/reducers/map.js
+++ b/app/src/reducers/map.js
@@ -13,7 +13,13 @@ import {
 } from 'actions/map';
 import { MAX_ZOOM_LEVEL } from 'config';
 import { SET_MAX_ZOOM } from 'layers/layersActions';
-import { SET_TILESET_ID, SET_TILESET_URL, SET_URL_WORKSPACE_ID, SET_WORKSPACE_ID } from 'actions/workspace';
+import {
+  SET_TILESET_ID,
+  SET_TILESET_URL,
+  SET_URL_WORKSPACE_ID,
+  SET_WORKSPACE_ID,
+  SET_WORKSPACE_OVERRIDE
+} from 'workspace/workspaceActions';
 
 const initialState = {
   isDrawing: false,
@@ -82,6 +88,9 @@ export default function (state = initialState, action) {
       return Object.assign({}, state, { workspaceId: action.payload });
     case DELETE_WORKSPACE_ID:
       return Object.assign({}, state, { workspaceId: null });
+    case SET_WORKSPACE_OVERRIDE:
+      return Object.assign({}, state, { workspaceOverride: action.payload });
+
 
     case SET_LAYER_INFO_MODAL: {
       const newState = Object.assign({}, state);

--- a/app/src/siteNav/components/MenuMobile.jsx
+++ b/app/src/siteNav/components/MenuMobile.jsx
@@ -52,7 +52,7 @@ class MenuMobile extends Component {
           <ul className={MenuMobileStyles.submenuMobile} >
             <li><a href={`${SITE_URL}/tutorials/`} >Tutorials</a></li>
             <li><a href={`${SITE_URL}/map-use/`} >Map Help</a></li>
-            <li><a href={`${SITE_URL}/data-help/`} >Data Help</a></li>            
+            <li><a href={`${SITE_URL}/data-help/`} >Data Help</a></li>
             <li><a href={`${SITE_URL}/definitions/`} >Definitions</a></li>
           </ul>
           <li><a href={`${SITE_URL}/sitemap/`} >Site Map</a></li>

--- a/app/src/siteNav/containers/Header.js
+++ b/app/src/siteNav/containers/Header.js
@@ -2,11 +2,12 @@ import { connect } from 'react-redux';
 import Header from 'siteNav/components/Header';
 import { login, logout } from 'user/userActions';
 import { setShareModalError, openShareModal } from 'share/shareActions';
-import { saveWorkspace, getWorkspace } from 'actions/workspace';
+import { saveWorkspace, getWorkspace } from 'workspace/workspaceActions';
 
 const mapStateToProps = state => ({
   loggedUser: state.user.loggedUser,
-  urlWorkspaceId: state.map.urlWorkspaceId
+  urlWorkspaceId: state.map.urlWorkspaceId,
+  isEmbedded: state.app.isEmbedded
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/src/siteNav/containers/MenuMobile.js
+++ b/app/src/siteNav/containers/MenuMobile.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import MenuMobile from 'siteNav/components/MenuMobile';
 import { login, logout } from 'user/userActions';
-import { getWorkspace } from 'actions/workspace';
+import { getWorkspace } from 'workspace/workspaceActions';
 import { setSupportModalVisibility } from 'siteNav/supportFormActions';
 
 const mapStateToProps = state => ({

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -103,6 +103,7 @@ const webpackConfig = {
       tracks: 'src/tracks',
       user: 'src/user',
       welcomeModal: 'src/welcomeModal',
+      workspace: 'src/workspace',
       components: 'src/components',
       config: 'src/config.js',
       constants: 'src/constants.js',


### PR DESCRIPTION
This implements https://github.com/GlobalFishingWatch/GFW-Tasks/issues/648

It can be tested by appending the following workspace override samples to the client's URL:
```
paramsPlainText={"vessels":[[5572477,"516-resample-v2",45017],[3535204,"516-resample-v2",38829]],"view":[6,-3,48],"innerExtent":[1478707468062,1479469642064],"outerExtent":[1477360207737,1480550400000]}
```
Or, using the base64 encoded version:
```
params=eyJ2ZXNzZWxzIjpbWzU1NzI0NzcsIjUxNi1yZXNhbXBsZS12MiIsNDUwMTddLFszNTM1MjA0LCI1MTYtcmVzYW1wbGUtdjIiLDM4ODI5XV0sInZpZXciOls2LC0zLDQ4XSwiaW5uZXJFeHRlbnQiOlsxNDc4NzA3NDY4MDYyLDE0Nzk0Njk2NDIwNjRdLCJvdXRlckV4dGVudCI6WzE0NzczNjAyMDc3MzcsMTQ4MDU1MDQwMDAwMF19
```
Note: this is encoded using `window.btoa` (not sure what should be used server side).

Not implemented but might be needed ?: adding a `hue` parameter to the vessel tracks.
Also, vessel tracks are set to visible automatically, maybe we want this to be configurable?
