### PR TITLE
use header templates to build URLs for tiles, tracks, info, search

### DIFF
--- a/app/src/actions/heatmap.js
+++ b/app/src/actions/heatmap.js
@@ -87,10 +87,9 @@ export function initHeatmapLayers() {
  * @param  {bool} isPBF                  true = read tile as MVT + PBF tile, rather than using Pelagos client
  * @return {Promise}                     a Promise that will be resolved when tile is loaded
  */
-function loadLayerTile(tileCoordinates, token, temporalExtentsIndices, { urls, temporalExtents, temporalExtentsLess, isPBF }) {
-  // TODO not sure why urls are array of arrays, clarify with Skytruth
-  const layerUrl = urls.default[0][0];
-  const pelagosPromises = getTilePromises(layerUrl, token, temporalExtents, {
+function loadLayerTile(tileCoordinates, token, temporalExtentsIndices, { endpoints, temporalExtents, temporalExtentsLess, isPBF }) {
+  const url = endpoints.tiles;
+  const pelagosPromises = getTilePromises(url, token, temporalExtents, {
     tileCoordinates,
     temporalExtentsIndices,
     temporalExtentsLess,
@@ -181,6 +180,7 @@ function getTiles(layerIds, referenceTiles, newTemporalExtentsToLoad) {
           : newTemporalExtentsToLoad[layerId];
 
         const temporalExtentsIndicesToLoad = difference(queriedTemporalExtentsIndices, tile.temporalExtentsIndicesLoaded);
+
         const tilePromise = loadLayerTile(
           referenceTile.tileCoordinates,
           token,

--- a/app/src/encounters/encountersActions.js
+++ b/app/src/encounters/encountersActions.js
@@ -2,6 +2,7 @@ import fetchEndpoint from 'util/fetchEndpoint';
 import { getTrack, deleteTracks } from 'tracks/tracksActions';
 import { VESSEL_TYPE_REEFER } from 'constants';
 import { ENCOUNTERS_VESSEL_COLOR, ENCOUNTERS_REEFER_COLOR } from 'config';
+import buildEndpoint from 'util/buildEndpoint';
 
 export const LOAD_ENCOUNTERS_INFO = 'LOAD_ENCOUNTERS_INFO';
 export const SET_ENCOUNTERS_INFO = 'SET_ENCOUNTERS_INFO';
@@ -65,8 +66,7 @@ export function setEncountersInfo(seriesgroup, tilesetId, encounterInfoEndpoint)
 
       encounterInfo.vessels.forEach((vessel) => {
         const workspaceLayer = workspaceLayers.find(layer => layer.tilesetId === vessel.tilesetId);
-        const url = workspaceLayer.url;
-        fetchEndpoint(`${url}/sub/seriesgroup=${vessel.seriesgroup}/info`, token).then((vesselInfo) => {
+        fetchEndpoint(buildEndpoint(workspaceLayer.header.endpoints.info, { id: seriesgroup }), token).then((vesselInfo) => {
           dispatch({
             type: SET_ENCOUNTERS_VESSEL_INFO,
             payload: {

--- a/app/src/layers/layersActions.js
+++ b/app/src/layers/layersActions.js
@@ -42,6 +42,13 @@ function loadLayerHeader(tilesetUrl, token) {
         return res.json();
       })
       .then((data) => {
+        // this a mock, remove me
+        data.endpoints = {
+          tiles: 'https://api-dot-world-fishing-827.appspot.com/v2/tilesets/516-resample-v2/{{startTimeISO}},{{endTimeISO}};{{z}},{{x}},{{y}}',
+          tracks: 'https://api-dot-world-fishing-827.appspot.com/v2/tilesets/516-resample-v2/sub/seriesgroup={{id}}/{{startTimeISO}},{{endTimeISO}};0,0,0',
+          info: 'https://api-dot-world-fishing-827.appspot.com/v2/tilesets/516-resample-v2/sub/seriesgroup={{id}}/info',
+          search: 'https://api-dot-world-fishing-827.appspot.com/v2/tilesets/516-resample-v2/search/?query={{query}}&limit={{limit}}&offset={{offset}}',
+        };
         resolve(data);
       }).catch((err) => {
         console.warn(err);

--- a/app/src/search/searchActions.js
+++ b/app/src/search/searchActions.js
@@ -3,6 +3,7 @@ import { LAYER_TYPES } from 'constants';
 import 'whatwg-fetch';
 import debounce from 'lodash/debounce';
 import getVesselName from 'util/getVesselName';
+import buildEndpoint from 'util/buildEndpoint';
 
 export const SET_SEARCH_RESULTS = 'SET_SEARCH_RESULTS';
 export const SET_SEARCH_TERM = 'SET_SEARCH_TERM';
@@ -29,13 +30,6 @@ const loadSearchResults = debounce((searchTerm, page, state, dispatch) => {
     };
   }
 
-  const searchParams = {
-    query: searchTerm,
-    limit: SEARCH_MODAL_PAGE_SIZE,
-    offset: page * SEARCH_MODAL_PAGE_SIZE
-  };
-  const queryArgs = Object.keys(searchParams).map(k => `${encodeURIComponent(k)}=${encodeURIComponent(searchParams[k])}`).join('&');
-
   let searchResultList = [];
   let searchResultCount = 0;
 
@@ -45,7 +39,11 @@ const loadSearchResults = debounce((searchTerm, page, state, dispatch) => {
 
   const searchLayerPromises = layers
     .map(layer =>
-      fetch(`${layer.url}/search/?${queryArgs}`, options)
+      fetch(buildEndpoint(layer.header.endpoints.search, {
+        query: encodeURIComponent(searchTerm),
+        limit: SEARCH_MODAL_PAGE_SIZE,
+        offset: page * SEARCH_MODAL_PAGE_SIZE
+      }), options)
         .then(response => response.json())
         .then((result) => {
           if (queryID !== searchQueryID) {

--- a/app/src/tracks/tracksActions.js
+++ b/app/src/tracks/tracksActions.js
@@ -39,7 +39,7 @@ export function getTrack({ tilesetId, seriesgroup, series, updateTimelineBounds,
       return;
     }
     const header = currentLayer.header;
-    const url = header.urls.search[0] || currentLayer.url;
+    const url = header.endpoints.tracks;
     const promises = getTilePromises(url, state.user.token, header.temporalExtents, { seriesgroup });
 
     dispatch({

--- a/app/src/util/buildEndpoint.js
+++ b/app/src/util/buildEndpoint.js
@@ -1,0 +1,9 @@
+import template from 'lodash/template';
+import templateSettings from 'lodash/templateSettings';
+
+export default (urlTemplate, urlParams) => {
+  templateSettings.interpolate = /{{([\s\S]+?)}}/g;
+  const urlTemplateCompiled = template(urlTemplate);
+  return urlTemplateCompiled(urlParams);
+};
+

--- a/app/src/util/heatmapTileData.js
+++ b/app/src/util/heatmapTileData.js
@@ -2,6 +2,7 @@ import PelagosClient from 'lib/pelagosClient';
 import pull from 'lodash/pull';
 import uniq from 'lodash/uniq';
 import sumBy from 'lodash/sumBy';
+import buildEndpoint from 'util/buildEndpoint';
 import convert from 'globalfishingwatch-convert';
 
 import { VESSEL_CLICK_TOLERANCE_PX } from 'config';
@@ -18,24 +19,25 @@ import getPBFTile from './getPBFTile';
  *                                  - temporalExtentsIndices: restrict to these temporalExtents indices
  * @returns {Array}                 an array of URLs for this tile
  */
-const getTemporalTileURLs = (tilesetUrl, temporalExtents, params) => {
+const getTemporalTileURLs = (urlTemplate, temporalExtents, params) => {
   const urls = [];
+
   (temporalExtents || [null]).forEach((extent, index) => {
-    let url = `${tilesetUrl}/`;
-    if (params.seriesgroup) {
-      url += `sub/seriesgroup=${params.seriesgroup}/`;
-    }
+    const urlParams = {
+      id: params.seriesgroup
+    };
     if (extent !== null && params.temporalExtentsLess !== true) {
-      const start = new Date(extent[0]).toISOString();
-      const end = new Date(extent[1]).toISOString();
-      url += `${start},${end};`;
+      urlParams.startTimeISO = new Date(extent[0]).toISOString();
+      urlParams.endTimeISO = new Date(extent[1]).toISOString();
     }
     if (params.tileCoordinates) {
-      url += `${params.tileCoordinates.zoom},${params.tileCoordinates.x},${params.tileCoordinates.y}`;
-    } else {
-      // meh.
-      url += '0,0,0';
+      urlParams.x = params.tileCoordinates.x;
+      urlParams.y = params.tileCoordinates.y;
+      urlParams.z = params.tileCoordinates.zoom;
     }
+
+    const url = buildEndpoint(urlTemplate, urlParams);
+
     if (!params.temporalExtentsIndices || params.temporalExtentsIndices.indexOf(index) > -1) {
       urls.push(url);
     }

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -18,15 +18,15 @@
           "id": "82f5ccde-6002-11e6-9f8e-0e05a8b3e3d7"
         },
         {
-          "title": "Fishing Effort",
-          "description": "Fishing effort",
-          "url": "https://api-dot-world-fishing-827.appspot.com/v2/tilesets/429-resample-v2-tms",
+          "title": "AIS Fishing effort",
+          "description": "AIS Fishing effort",
+          "url": "https://api-dot-world-fishing-827.appspot.com/v2/tilesets/516-resample-v2",
           "visible": true,
           "hue": 182,
           "type": "ClusterAnimation",
           "opacity": 1,
-          "tilesetId": "429-resample-v2-tms",
-          "id": "fishing"
+          "id": "fishing2",
+          "tilesetId": "516-resample-v2"
         },
         {
           "title": "MPA - No Take",


### PR DESCRIPTION
See: https://github.com/GlobalFishingWatch/GFW-Tasks/issues/661

Warning: this PR removes support for layers that don't have an `endpoints` object in their header. I suggest we merge only after deploying the corresponding API changes. 