### PR TITLE
failsafe to continue loading workspace when timebar data fails

### DIFF
--- a/app/src/timebar/timebarActions.js
+++ b/app/src/timebar/timebarActions.js
@@ -30,6 +30,17 @@ export function loadTimebarChartData(startDate, endDate) {
         // they should be able to load in parallel but this will need a review
         // of the Timebar component
         dispatch(getLayerLibrary());
+      })
+      .catch(() => {
+        console.warn('Error loading Timebar data');
+        dispatch({
+          type: SET_TIMEBAR_CHART_DATA,
+          payload: [
+            { date: 1325376000000, value: 1 },
+            { date: 1520640000000, value: 1 }
+          ]
+        });
+        dispatch(getLayerLibrary());
       });
   };
 }


### PR DESCRIPTION
I have a CORS issue in production (only on Firefox strangely) with the JSON endpoints for Timebar data. When this fails, the layer library does not get loaded which causes the whole app to crash. This is a structural issue that we need to fix later. 
For now this is a simple hotfix that just loads dummy data.