### PR TITLE
autoscroll when opening vesselInfo or encounters panel

### DIFF
--- a/app/src/mapPanels/rightControlPanel/components/ControlPanel.jsx
+++ b/app/src/mapPanels/rightControlPanel/components/ControlPanel.jsx
@@ -30,10 +30,33 @@ class ControlPanel extends Component {
     this.onCloseLayersSubMenu = this.onCloseLayersSubMenu.bind(this);
   }
 
-  componentDidUpdate() {
-    if (this.props.isReportStarted === true) {
-      this.controlPanelRef.scrollTop = this.controlPanelRef.clientHeight;
+  componentDidUpdate(prevProps) {
+    if (
+      (this.props.isReportStarted === true && prevProps.isReportStarted !== this.props.isReportStarted) ||
+      (this.props.encountersInfo !== null && prevProps.encountersInfo !== this.props.encountersInfo) ||
+      (this.props.currentlyShownVessel !== null && prevProps.currentlyShownVessel !== this.props.currentlyShownVessel)
+    ) {
+      this._animateScroll();
     }
+  }
+
+  _animateScroll() {
+    const targetY = this.controlPanelRef.clientHeight;
+    let nextY = this.controlPanelRef.scrollTop;
+    const step = () => {
+      const currentY = nextY;
+      const deltaY = targetY - currentY;
+      const incrementY = deltaY * 0.1;
+      nextY += incrementY;
+      this.controlPanelRef.scrollTop = nextY;
+
+      if (nextY < targetY - 5) {
+        window.requestAnimationFrame(step);
+      } else {
+        this.controlPanelRef.scrollTop = targetY;
+      }
+    };
+    window.requestAnimationFrame(step);
   }
 
   onCloseVesselsSubMenu() {
@@ -260,7 +283,9 @@ ControlPanel.propTypes = {
   vessels: PropTypes.array,
   numPinnedVessels: PropTypes.number.isRequired,
   numFilters: PropTypes.number.isRequired,
-  isDrawing: PropTypes.bool
+  isDrawing: PropTypes.bool,
+  encountersInfo: PropTypes.object,
+  currentlyShownVessel: PropTypes.object
 };
 
 export default ControlPanel;

--- a/app/src/mapPanels/rightControlPanel/containers/ControlPanel.js
+++ b/app/src/mapPanels/rightControlPanel/containers/ControlPanel.js
@@ -19,7 +19,9 @@ const mapStateToProps = state => ({
   userPermissions: state.user.userPermissions,
   vessels: state.vesselInfo.vessels,
   numPinnedVessels: state.vesselInfo.vessels.filter(vessel => vessel.pinned === true).length,
-  numFilters: state.filterGroups.filterGroups.filter(filter => filter.visible === true).length
+  numFilters: state.filterGroups.filterGroups.filter(filter => filter.visible === true).length,
+  encountersInfo: state.encounters.encountersInfo,
+  currentlyShownVessel: state.vesselInfo.currentlyShownVessel
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
Fix for https://github.com/GlobalFishingWatch/GFW-Tasks/issues/677

![fishing-controlpanelscroll](https://user-images.githubusercontent.com/1583415/37901198-d286751c-30f0-11e8-834e-a1ffc79ccf99.gif)
