### PR TITLE
use custom field name as id when querying heatmap point

### DIFF
--- a/app/src/actions/heatmap.js
+++ b/app/src/actions/heatmap.js
@@ -482,8 +482,8 @@ export function getVesselFromHeatmap(tileQuery, latLng) {
       });
     } else {
       dispatch(trackMapClicked(latLng.lat(), latLng.lng(), 'vessel'));
+      const id = (layer.header.info.id === undefined) ? foundVessels[0].seriesgroup : foundVessels[0][layer.header.info.id];
       const selectedSeries = foundVessels[0].series;
-      const selectedSeriesgroup = foundVessels[0].seriesgroup;
 
       if (layer.subtype === LAYER_TYPES.Encounters) {
         if (layer.header.endpoints === undefined || layer.header.endpoints.info === undefined) {
@@ -492,7 +492,7 @@ export function getVesselFromHeatmap(tileQuery, latLng) {
           dispatch(setEncountersInfo(selectedSeries, layer.tilesetId, layer.header.endpoints.info));
         }
       } else {
-        dispatch(addVessel(layer.tilesetId, selectedSeriesgroup, selectedSeries));
+        dispatch(addVessel(layer.tilesetId, id, selectedSeries));
       }
 
     }


### PR DESCRIPTION
Fix for https://github.com/GlobalFishingWatch/GFW-Tasks/issues/704

This will use the field set in `header.info.id`, when available (otherwise it falls back to `seriesgroup`) to build a query to the `info` endpoint.

I wasn't able to test this for the VIIRS layer because:
- that field is not set in the header yet;
- the layer tiles points do not have a `virrs_event_id`. It is not declared in `colsByName`, nor it is present in the actual Float32Arrays. 

Additionally, is it normal that the VIIRS layer has the following as `endpoint.info` ?
"https://api-dot-skytruth-pleuston.appspot.com/v2/tilesets/gfw-tasks-644-viirs-qf-all-v2/sub/seriesgroup={{id}}/info
Where logically it should be `...sub/virrs_event_id={{id}}...`

Note: on the client side, Encounters, as well as the heatmap highlight mechanism use hardcoded seriesgroup / series. This is not clean and scalable, but it needs to be changed in various places, so I suggest doing this on the `mapbox` branch (I've updated the TODO here https://github.com/GlobalFishingWatch/GFW-Tasks/issues/679). 