### PR TITLE
Search results fixes

### DIFF
--- a/app/src/search/components/SearchModal.jsx
+++ b/app/src/search/components/SearchModal.jsx
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import SearchResult from 'search/containers/SearchResult';
 import PaginatorStyles from 'styles/components/shared/paginator.scss';
 import ReactPaginate from 'react-paginate';
-import { SEARCH_QUERY_MINIMUM_LIMIT, SEARCH_MODAL_PAGE_SIZE } from 'config';
+import { SEARCH_QUERY_MINIMUM_LIMIT } from 'config';
 import ModalStyles from 'styles/components/shared/modal.scss';
 import ResultListStyles from 'styles/search/result-list.scss';
 import SearchModalStyles from 'styles/components/map/search-modal.scss';
@@ -60,7 +60,7 @@ class SearchModal extends Component {
 
     if (this.props.searching) {
       searchResults = this.renderSearchingMessage();
-    } else if (this.props.count && this.props.searchTerm.length >= SEARCH_QUERY_MINIMUM_LIMIT) {
+    } else if (this.props.pageCount && this.props.searchTerm.length >= SEARCH_QUERY_MINIMUM_LIMIT) {
       searchResults = this.renderSearchResults();
     } else if (this.props.searchTerm.length < SEARCH_QUERY_MINIMUM_LIMIT && this.props.searchTerm.length > 0) {
       searchResults = this.renderShortSearchWordMessage();
@@ -110,7 +110,7 @@ class SearchModal extends Component {
             breakLabel={<span >...</span >}
             pageClassName={PaginatorStyles.pageItem}
             breakClassName={PaginatorStyles.pageItem}
-            pageCount={Math.ceil(this.props.count / SEARCH_MODAL_PAGE_SIZE)}
+            pageCount={this.props.pageCount}
             pageRangeDisplayed={3}
             onPageChange={e => this.onPageChange(e.selected)}
             forcePage={this.props.page}
@@ -153,7 +153,7 @@ SearchModal.propTypes = {
   entries: PropTypes.array, /*
    Number of total search results
    */
-  count: PropTypes.number, /*
+  pageCount: PropTypes.number, /*
    If search is in progress
    */
   searching: PropTypes.bool, /*

--- a/app/src/search/components/SearchPanel.jsx
+++ b/app/src/search/components/SearchPanel.jsx
@@ -87,7 +87,7 @@ class SearchPanel extends Component {
 
     if (this.props.searching) {
       searchResults = this.renderSearchingMessage();
-    } else if (this.props.count && this.props.searchTerm.length >= SEARCH_QUERY_MINIMUM_LIMIT) {
+    } else if (this.props.pageCount && this.props.searchTerm.length >= SEARCH_QUERY_MINIMUM_LIMIT) {
       searchResults = this.renderSearchResults();
     } else if (this.props.searchTerm.length < SEARCH_QUERY_MINIMUM_LIMIT && this.props.searchTerm.length > 0) {
       searchResults = this.renderShortSearchWordMessage();
@@ -122,16 +122,18 @@ class SearchPanel extends Component {
           >
             {searchResults}
           </ul >
-          {this.props.searchTerm.length >= SEARCH_QUERY_MINIMUM_LIMIT && !this.props.searching && this.props.count > SEARCH_RESULTS_LIMIT &&
-          <div className={searchPanelStyles.paginationContainer} >
-            <button
-              className={classnames(MapButtonStyles.button, MapButtonStyles._wide,
-                MapButtonStyles._filled, searchPanelStyles.paginationButton)}
-              onClick={() => this.onClickMoreResults()}
-            >
-              more results
-            </button >
-          </div >}
+          {this.props.searchTerm.length >= SEARCH_QUERY_MINIMUM_LIMIT
+            && !this.props.searching
+            && this.props.pageCount > SEARCH_RESULTS_LIMIT &&
+            <div className={searchPanelStyles.paginationContainer} >
+              <button
+                className={classnames(MapButtonStyles.button, MapButtonStyles._wide,
+                  MapButtonStyles._filled, searchPanelStyles.paginationButton)}
+                onClick={() => this.onClickMoreResults()}
+              >
+                more results
+              </button >
+            </div >}
         </div >
       </div >);
   }
@@ -148,7 +150,7 @@ SearchPanel.propTypes = {
   /*
    Number of total search results
    */
-  count: PropTypes.number,
+  pageCount: PropTypes.number,
   /*
    If search is in progress
    */

--- a/app/src/search/components/SearchResult.jsx
+++ b/app/src/search/components/SearchResult.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
-/* eslint-disable react/no-danger */
 import React, { Component } from 'react';
+import classnames from 'classnames';
 import ResultListStyles from 'styles/search/result-list.scss';
 
 class SearchResult extends Component {
@@ -10,11 +10,21 @@ class SearchResult extends Component {
     this.props.closeSearch();
   }
 
-  highlightWord(strReplace, str) {
-    const regX = new RegExp(strReplace, 'i');
-    const highlight = `<span class="${ResultListStyles.highlight}">${strReplace.toUpperCase()}</span>`;
-
-    return str.replace(regX, highlight);
+  renderLine(searchTerm, lineText) {
+    const searchTermWords = searchTerm.toUpperCase().split(' ');
+    const lineTextWords = lineText.split(' ');
+    return (
+      <span className={ResultListStyles.mainResultLabel}>
+        {lineTextWords.map((lineWord, i) => (
+          <span
+            key={`res${i}`}
+            className={classnames({ [ResultListStyles.highlight]: searchTermWords.indexOf(lineWord) > -1 })}
+          >
+            {lineWord}{' '}
+          </span>
+        ))}
+      </span>
+    );
   }
 
   render() {
@@ -23,8 +33,6 @@ class SearchResult extends Component {
       this.props.vesselInfo.mmsi === undefined ||
       (this.props.vesselInfo.mmsi !== undefined && this.props.vesselInfo.mmsi === title)
     ) ? '' : this.props.vesselInfo.mmsi;
-    const highlightName = this.highlightWord(this.props.searchTerm, title);
-    const highlightMMSI = this.highlightWord(this.props.searchTerm, MMSI);
 
     return (
       <li
@@ -33,16 +41,9 @@ class SearchResult extends Component {
           this.onDrawVessel(event);
         }}
       >
-        <span
-          dangerouslySetInnerHTML={{ __html: highlightName }}
-          className={ResultListStyles.mainResultLabel}
-        />
-        {MMSI &&
-        <span
-          dangerouslySetInnerHTML={{ __html: highlightMMSI }}
-          className={ResultListStyles.subResultLabel}
-        />}
-      </li >
+        {this.renderLine(this.props.searchTerm, title)}
+        {MMSI && this.renderLine(this.props.searchTerm, MMSI)}
+      </li>
     );
   }
 }

--- a/app/src/search/containers/SearchModal.jsx
+++ b/app/src/search/containers/SearchModal.jsx
@@ -4,7 +4,7 @@ import { setSearchTerm, setSearchModalVisibility, setSearchPage } from 'search/s
 
 const mapStateToProps = state => ({
   entries: state.search.entries,
-  count: state.search.count,
+  pageCount: state.search.pageCount,
   page: state.search.page,
   searching: state.search.searching,
   searchTerm: state.search.searchTerm

--- a/app/src/search/containers/SearchPanel.js
+++ b/app/src/search/containers/SearchPanel.js
@@ -4,7 +4,7 @@ import { setSearchTerm, setSearchModalVisibility, setSearchResultVisibility } fr
 
 const mapStateToProps = state => ({
   entries: state.search.entries,
-  count: state.search.count,
+  pageCount: state.search.pageCount,
   searching: state.search.searching,
   searchTerm: state.search.searchTerm,
   searchModalOpen: state.search.searchModalOpen,

--- a/app/src/search/searchActions.js
+++ b/app/src/search/searchActions.js
@@ -47,19 +47,21 @@ const loadSearchResults = debounce((searchTerm, page, state, dispatch) => {
         console.warn('search term differs, searching for', searchTerm, 'receiving', resultContainers[0].result.query);
       }
       let searchResultList = [];
-      let searchResultCount = 0;
+      let pageCount = 0;
       resultContainers.forEach((resultContainer) => {
         resultContainer.result.entries.forEach((entry) => {
           entry.tilesetId = resultContainer.layer.tilesetId;
           entry.title = getVesselName(entry, resultContainer.layer.header.info.fields);
         });
         searchResultList = searchResultList.concat(resultContainer.result.entries);
-        searchResultCount += resultContainer.result.total;
+        const thisSearchPageCount = Math.ceil(resultContainer.result.total / resultContainer.result.limit);
+        pageCount = Math.max(thisSearchPageCount, pageCount);
       });
       dispatch({
         type: SET_SEARCH_RESULTS,
         payload: {
-          entries: searchResultList, count: searchResultCount
+          entries: searchResultList,
+          pageCount
         }
       });
     });

--- a/app/src/search/searchReducer.js
+++ b/app/src/search/searchReducer.js
@@ -21,7 +21,7 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case SET_SEARCH_RESULTS:
       return Object.assign({}, state, {
-        count: action.payload.count,
+        pageCount: action.payload.pageCount,
         entries: action.payload.entries,
         searching: false
       });


### PR DESCRIPTION
Contains the following fixes related to vessel search:
- consistent ordering of search results (fixes https://github.com/GlobalFishingWatch/GFW-Tasks/issues/717)
- fixed an issue where the number of pages available in paginated search results was always higher than needed, resulting in empty pages
- fixed an issue where words were not highlighted when search contained several words (ie a search for "__TUNA QUEEN__" would not result in highlighting "SOME VESSEL WITH THE WORD __QUEEN__")  