### PR TITLE
display humanized datetime in vesselinfo

### DIFF
--- a/app/src/vesselInfo/components/VesselInfoDetails.jsx
+++ b/app/src/vesselInfo/components/VesselInfoDetails.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { getCountry } from 'iso-3166-1-alpha-2';
+import moment from 'moment';
+import { FORMAT_DATE, FORMAT_TIME } from 'config';
 
 import infoPanelStyles from 'styles/components/info-panel.scss';
 
@@ -27,7 +29,10 @@ class VesselInfoDetails extends Component {
       if (vesselInfo[field.id] === undefined) {
         return;
       }
-      switch (field.kind) {
+
+      const kind = field.kind || field.id;
+
+      switch (kind) {
         case 'prefixedCSVMultiLink':
           if (!vesselInfo[field.id]) {
             break;
@@ -75,6 +80,16 @@ class VesselInfoDetails extends Component {
             <span className={infoPanelStyles.value} >{getCountry(vesselInfo[field.id]) || '---'}</span>
           </div>);
           break;
+        case 'datetime': {
+          const humanizedDate = vesselInfo[field.id] ?
+            moment(vesselInfo[field.id]).format(`${FORMAT_DATE} ${FORMAT_TIME}`) :
+            null;
+          renderedFieldList.push(<div key={field.id} className={infoPanelStyles.rowInfo}>
+            <span className={infoPanelStyles.key}>{field.display}</span>
+            <span className={infoPanelStyles.value}>{humanizedDate || '---'}</span>
+          </div>);
+          break;
+        }
         default:
           renderedFieldList.push(<div key={field.id} className={infoPanelStyles.rowInfo} >
             <span className={infoPanelStyles.key} >{field.display}</span>


### PR DESCRIPTION
Will render any field named 'datetime' as a humanized date/time. Required for VIIRS layer.

<img width="317" alt="screen shot 2018-05-25 at 10 41 19" src="https://user-images.githubusercontent.com/1583415/40535351-2a44e47c-6009-11e8-8782-18493c443f55.png">


