### PR TITLE
Enables sourcemaps in production builds

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -238,7 +238,9 @@ const webpackConfig = {
 
 // Environment configuration
 if (envVariables.NODE_ENV === 'production') {
-  webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin());
+  webpackConfig.plugins.push(new webpack.optimize.UglifyJsPlugin({
+    sourceMap: true
+  }));
   webpackConfig.devtool = 'source-map';
   webpackConfig.resolve.alias.react = path.join(rootPath, 'node_modules/react/dist/react.min.js');
   webpackConfig.resolve.alias['react-dom'] = path.join(rootPath, 'node_modules/react-dom/dist/react-dom.min.js');


### PR DESCRIPTION
We have a bad configuration setting in the uglifyjs plugin which is causing the app not to load the sourcemaps in production builds even if it should.