### PR TITLE
compile default workspace

### DIFF
--- a/app/src/workspace/workspace.js
+++ b/app/src/workspace/workspace.js
@@ -1,0 +1,3 @@
+// AUTOMATICALLY OVERRIDEN BY PREINSTALL SCRIPT
+const defaultWorkspace = {};
+export default defaultWorkspace;

--- a/bin/retrieve-workspace.js
+++ b/bin/retrieve-workspace.js
@@ -1,0 +1,43 @@
+require('dotenv').config({ silent: true });
+const https = require('https');
+const path = require('path');
+const fs = require('fs');
+
+const envVariables = process.env;
+const WORKSPACE_PATH = 'app/src/workspace/workspace.js';
+
+console.log('Retrieving worskpace with configuration:');
+console.log('V2_API_ENDPOINT', envVariables.V2_API_ENDPOINT);
+console.log('DEFAULT_WORKSPACE', envVariables.DEFAULT_WORKSPACE);
+
+if (!envVariables.DEFAULT_WORKSPACE || !envVariables.V2_API_ENDPOINT) {
+  console.log('Error reading workspace');
+  process.exit(1);
+}
+
+https.get(`${envVariables.V2_API_ENDPOINT}/workspaces/${envVariables.DEFAULT_WORKSPACE}`, (resp) => {
+  let data = '';
+  resp.on('data', (chunk) => {
+    data += chunk;
+  });
+  resp.on('end', () => {
+    try {
+      const workspaceJSON = JSON.parse(data);
+      let workspace = JSON.stringify(workspaceJSON, null, 2);
+      workspace = `
+// AUTOMATICALLY RETRIEVED FROM ENV VARIABLES. DO NOT EDIT.
+const defaultWorkspace = ${workspace};
+export default defaultWorkspace;
+      `;
+      const finalPath = path.join(process.cwd(), WORKSPACE_PATH);
+      console.log('Writing workspace to', finalPath);
+      fs.writeFileSync(finalPath, workspace);
+
+    } catch (err) {
+      console.log('Could not parse/write workspace: ' + err.message);
+    }
+  });
+}).on('error', (err) => {
+  console.log('Could not load workspace: ' + err.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint-js": "./node_modules/.bin/eslint -c .eslintrc --ext .jsx,.js app",
     "lint-sass": "sass-lint -v -q",
     "lint:js": "npm run lint-js",
+    "retrieve-workspace": "node ./bin/retrieve-workspace.js",
+    "preinstall": "npm run retrieve-workspace",
     "test": "npm run lint-js && npm run lint-sass"
   },
   "repository": {


### PR DESCRIPTION
This adds a script that retrieves the default workspace from V2_API_ENDPOINT and DEFAULT_WORKSPACE env vars, writes it to a JS file that gets compiled in the JS bundle, avoiding having to fetch it at runtime.

The script is automatically triggered when doing `npm install` (so before every deployment).

If the the URL as worskpace id, it will still load it as before.
Also, if LOCAL_WORKSPACE is set, it will override the bundled workspace - this should be for dev purposes only and should not be in env vars used for deployment.