### PR TITLE
Auto timeline

### DIFF
--- a/app/src/workspace/workspaceActions.js
+++ b/app/src/workspace/workspaceActions.js
@@ -196,12 +196,34 @@ function dispatchActions(workspaceData, dispatch, getState) {
   }));
 
   // We update the dates of the timeline
+  const autoTimeline = workspaceData.timeline.auto !== undefined;
+  let timelineInnerDates;
+  let timelineOuterDates;
+  if (autoTimeline) {
+    const ONE_DAY = 24 * 60 * 60 * 1000;
+    const daysEndInnerOuterFromToday = workspaceData.timeline.auto.daysEndInnerOuterFromToday || 4;
+    const daysInnerExtent = workspaceData.timeline.auto.daysInnerExtent || 30;
+    // today - n days
+    const end = new Date().getTime() - (daysEndInnerOuterFromToday * ONE_DAY);
+    // inner should be 30 days long
+    const innerStart = end - (daysInnerExtent * ONE_DAY);
+    // start outer at beginning of year
+    const innerStartYear = new Date(innerStart).getFullYear();
+    const outerStart = new Date(innerStartYear, 0, 1).getTime() + (ONE_DAY - 1);
+    timelineInnerDates = [new Date(innerStart), new Date(end)];
+    timelineOuterDates = [new Date(outerStart), new Date(end)];
+  } else {
+    timelineInnerDates = workspaceData.timeline.innerExtent.map(d => new Date(d));
+    timelineOuterDates = workspaceData.timeline.outerExtent.map(d => new Date(d));
+  }
+
+
   dispatch({
     type: SET_INNER_TIMELINE_DATES_FROM_WORKSPACE,
-    payload: workspaceData.timelineInnerDates
+    payload: timelineInnerDates
   });
 
-  dispatch(setOuterTimelineDates(workspaceData.timelineOuterDates));
+  dispatch(setOuterTimelineDates(timelineOuterDates));
 
   dispatch(initBasemap(workspaceData.basemap, workspaceData.basemapOptions));
 
@@ -291,8 +313,7 @@ function processNewWorkspace(data) {
   return {
     zoom: workspace.map.zoom,
     center: workspace.map.center,
-    timelineInnerDates: workspace.timeline.innerExtent.map(d => new Date(d)),
-    timelineOuterDates: workspace.timeline.outerExtent.map(d => new Date(d)),
+    timeline: workspace.timeline,
     timelineSpeed: workspace.timelineSpeed,
     basemap: workspace.basemap,
     basemapOptions: workspace.basemapOptions || [],

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -48,14 +48,10 @@
     "basemap": "hybrid",
     "basemapOptions": ["labels", "graticules"],
     "timeline": {
-      "innerExtent": [
-        1464739200000,
-        1467331200000
-      ],
-      "outerExtent": [
-        1451689200000,
-        1480550400000
-      ]
+      "auto": {
+        "daysEndInnerOuterFromToday": 4,
+        "daysInnerExtent": 30
+      }
     },
     "timelineSpeed": 1,
     "filterGroups": []


### PR DESCRIPTION
This introduce a different `auto` mode for the `timeline` workspace parameter:
 ```
    "timeline": {
      "auto": {
        "daysEndInnerOuterFromToday": 4,
        "daysInnerExtent": 30
      }
    }
```
When `auto` exists on  `timeline`, it replaces the `innerExtent` and `outerExtent` parameters.
It's possible to also just set `"auto": true`, in which case `daysEndInnerOuterFromToday`(position of the end of the inner and outer extents expressed a number of days from today) and `daysInnerExtent` (length of the inner extent in days) are set to defaults (4 and 30 days).

I believe that this simple approach (rather than using layers headers) works for our use case. It also avoids that very awkward "timeline jump" between app start and all layer headers loaded.