### PR TITLE
High zoom levels handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0
+- Deeper zoom levels up to 14, even when activity layer tiles are not visible (https://github.com/GlobalFishingWatch/map-client/pull/942)
+
 ## 2.4.0 RC2
 - Fixed issue that preventend building in production mode
 

--- a/app/src/activityLayers/containers/ActivityLayers.js
+++ b/app/src/activityLayers/containers/ActivityLayers.js
@@ -9,6 +9,7 @@ const mapStateToProps = state => ({
   timelineOverExtentIndexes: state.filters.timelineOverExtentIndexes,
   highlightedVessels: state.heatmap.highlightedVessels,
   highlightedClickedVessel: state.heatmap.highlightedClickedVessel,
+  viewport: state.mapViewport.viewport,
   zoom: state.mapViewport.viewport.zoom,
   layerFilters: state.filterGroups.layerFilters,
   vesselTracks: state.vesselInfo.vessels,

--- a/app/src/activityLayers/heatmapTilesActions.js
+++ b/app/src/activityLayers/heatmapTilesActions.js
@@ -12,10 +12,13 @@ export const RELEASE_MARKED_TILES_UIDS = 'RELEASE_MARKED_TILES_UIDS';
 
 // restrict tilecover to a single zoom level
 // could be customized to load less or more detailed tiles
-const getTilecoverLimits = zoom => ({
-  min_zoom: Math.ceil(zoom + 0.5),
-  max_zoom: Math.ceil(zoom + 0.5)
-});
+const getTilecoverLimits = (viewportZoom, forcedZoom) => {
+  const zoom = (viewportZoom === null) ? forcedZoom : Math.ceil(viewportZoom + 0.5);
+  return {
+    min_zoom: zoom,
+    max_zoom: zoom
+  };
+};
 
 export const markTileAsLoaded = tileUids => (dispatch, getState) => {
   dispatch({
@@ -131,10 +134,12 @@ export const updateHeatmapTilesFromViewport = (forceLoadingAllVisibleTiles = fal
   const [w, s, e, n] = [wn[0], es[1], es[0], wn[1]];
   const boundsPolygonsCoordinates = [];
 
-  const limits = getTilecoverLimits(viewport.zoom);
-
+  let limits = getTilecoverLimits(viewport.zoom);
   if (limits.max_zoom > ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING) {
-    return;
+    if (forceLoadingAllVisibleTiles !== true) {
+      return;
+    }
+    limits = getTilecoverLimits(null, ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING);
   }
 
   if (e > 180 || w < -180) {

--- a/app/src/activityLayers/heatmapTilesActions.js
+++ b/app/src/activityLayers/heatmapTilesActions.js
@@ -12,11 +12,17 @@ export const RELEASE_MARKED_TILES_UIDS = 'RELEASE_MARKED_TILES_UIDS';
 
 // restrict tilecover to a single zoom level
 // could be customized to load less or more detailed tiles
-const getTilecoverLimits = (viewportZoom, forcedZoom) => {
-  const zoom = (viewportZoom === null) ? forcedZoom : Math.ceil(viewportZoom + 0.5);
+const getTilecoverLimits = (viewportZoom) => {
+  let zoom = Math.ceil(viewportZoom + 0.5);
+  let tilesAvailable = true;
+  if (zoom > ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING) {
+    zoom = ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING;
+    tilesAvailable = false;
+  }
   return {
     min_zoom: zoom,
-    max_zoom: zoom
+    max_zoom: zoom,
+    tilesAvailable
   };
 };
 
@@ -134,12 +140,9 @@ export const updateHeatmapTilesFromViewport = (forceLoadingAllVisibleTiles = fal
   const [w, s, e, n] = [wn[0], es[1], es[0], wn[1]];
   const boundsPolygonsCoordinates = [];
 
-  let limits = getTilecoverLimits(viewport.zoom);
-  if (limits.max_zoom > ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING) {
-    if (forceLoadingAllVisibleTiles !== true) {
-      return;
-    }
-    limits = getTilecoverLimits(null, ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING);
+  const limits = getTilecoverLimits(viewport.zoom);
+  if (limits.tilesAvailable === false && forceLoadingAllVisibleTiles !== true) {
+    return;
   }
 
   if (e > 180 || w < -180) {

--- a/app/src/config.js
+++ b/app/src/config.js
@@ -28,7 +28,15 @@ export const TIMELINE_MAX_SPEED = 16;
 export const TIMELINE_MIN_SPEED = 0.03125;
 
 export const MIN_ZOOM_LEVEL = 1;
-export const MAX_ZOOM_LEVEL = 12;
+
+// user can zoom up to this z level, but it doesn't guarantee availability of tiles
+export const MAX_ZOOM_LEVEL = 14;
+
+// Limit tile loading for activity layers up to this z level.
+// Beyond, layer is still displayed but with coarse data from the lower zoom level
+export const ACTIVITY_LAYERS_MAX_ZOOM_LEVEL_TILE_LOADING = 10;
+
+
 export const MAX_AUTO_ZOOM_LONGITUDE_SPAN = 200;
 export const CLUSTER_CLICK_ZOOM_INCREMENT = 1;
 

--- a/app/src/layers/layersActions.js
+++ b/app/src/layers/layersActions.js
@@ -2,7 +2,6 @@ import find from 'lodash/find';
 import { LAYER_TYPES, LAYER_TYPES_WITH_HEADER, HEADERLESS_LAYERS, TEMPORAL_EXTENTLESS, LAYER_TYPES_MAPBOX_GL } from 'constants';
 import { SET_OVERALL_TIMELINE_DATES } from 'filters/filtersActions';
 import { refreshFlagFiltersLayers } from 'filters/filterGroupsActions';
-import { setMaxZoom } from 'map/mapViewportActions';
 import { updateMapStyle } from 'map/mapStyleActions';
 import {
   initHeatmapLayers,
@@ -62,10 +61,6 @@ function loadLayerHeader(tilesetUrl, token) {
 // TODO This shouldn't be here
 function setGlobalFiltersFromHeader(data) {
   return (dispatch) => {
-    if (data.maxZoom !== undefined) {
-      dispatch(setMaxZoom(data.maxZoom));
-    }
-
     if (!!data.colsByName && !!data.colsByName.datetime && !!data.colsByName.datetime.max && !!data.colsByName.datetime.min) {
       dispatch({
         type: SET_OVERALL_TIMELINE_DATES,

--- a/app/src/map/mapViewportActions.js
+++ b/app/src/map/mapViewportActions.js
@@ -5,7 +5,6 @@ import { CLUSTER_CLICK_ZOOM_INCREMENT } from 'config';
 export const SET_VIEWPORT = 'SET_VIEWPORT';
 export const UPDATE_VIEWPORT = 'UPDATE_VIEWPORT';
 export const SET_ZOOM_INCREMENT = 'SET_ZOOM_INCREMENT';
-export const SET_MAX_ZOOM = 'SET_MAX_ZOOM';
 export const SET_MOUSE_LAT_LONG = 'SET_MOUSE_LAT_LONG';
 export const TRANSITION_END = 'TRANSITION_END';
 
@@ -46,12 +45,6 @@ export const incrementZoom = () => (dispatch) => {
 export const decrementZoom = () => (dispatch) => {
   dispatch(updateZoom(-1));
 };
-
-
-export const setMaxZoom = maxZoom => ({
-  type: SET_MAX_ZOOM,
-  payload: maxZoom
-});
 
 export const setMouseLatLong = (lat, long) => ({
   type: SET_MOUSE_LAT_LONG,

--- a/app/src/map/mapViewportReducer.js
+++ b/app/src/map/mapViewportReducer.js
@@ -2,7 +2,6 @@ import {
   SET_VIEWPORT,
   UPDATE_VIEWPORT,
   SET_ZOOM_INCREMENT,
-  SET_MAX_ZOOM,
   SET_MOUSE_LAT_LONG,
   TRANSITION_END
 } from 'map/mapViewportActions';
@@ -76,15 +75,6 @@ export default function (state = initialState, action) {
         canZoomOut: zoom > state.minZoom,
         prevZoom: state.viewport.zoom,
         currentTransition: TRANSITION_TYPE.ZOOM
-      };
-    }
-
-    case SET_MAX_ZOOM: {
-      return {
-        ...state,
-        maxZoom: action.payload,
-        canZoomIn: state.viewport.zoom < state.maxZoom,
-        canZoomOut: state.viewport.zoom > state.minZoom
       };
     }
 


### PR DESCRIPTION
Fix for https://github.com/GlobalFishingWatch/map-client/issues/940

Previous behaviour:
User could not zoom beyond z level 10. This value was set on each activity layer header (`max_zoom`) and apparently was always the same for all layers. The client did not correctly handle different zoom levels anyways.

Now:
User can zoom up to a more detailed z level, set arbitrarily as 14.
Removed faulty z level logic, maximum zoom level for loading of tiles is hardcoded at 10. For z levels 11-14, the map will still display activity layers, but with the last available z level (10)

@enriquetuya let me know if per-layer max zoom level is actually required (considering we never had this working on the client side and that it's not trivial to implement)  