### PR TITLE
Workspace gl layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 3.0.0
+- Allow custom Mapbox GL JSON style in workspaces (https://github.com/GlobalFishingWatch/map-client/pull/943)
+
 ## 2.4.0 RC2
 - Fixed issue that preventend building in production mode
 

--- a/app/src/map/gl-styles/style.json
+++ b/app/src/map/gl-styles/style.json
@@ -152,8 +152,7 @@
       "id": "satellite",
       "type": "raster",
       "source": "satellite",
-      "layout": {},
-      "paint": {}
+      "layout": {}
     },
     {
       "id": "north-star",
@@ -161,8 +160,7 @@
       "source": "north-star",
       "layout": {
         "visibility": "none"
-      },
-      "paint": {}
+      }
     },
     {
       "id": "bathymetry",
@@ -221,7 +219,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -236,8 +233,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "mparu",
@@ -247,7 +243,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -262,8 +257,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "eez",
@@ -273,7 +267,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -288,8 +281,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "highseas",
@@ -299,7 +291,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -314,8 +305,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "rfmo",
@@ -325,7 +315,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -340,8 +329,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "6",
@@ -351,7 +339,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -366,8 +353,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "protectedplanet",
@@ -377,7 +363,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -392,8 +377,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "mpatlas",
@@ -403,7 +387,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -418,8 +401,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "falklands_conservation",
@@ -429,7 +411,6 @@
       "layout": { 
        "visibility": "none"
       },
-      "paint": {},
       "interactive": true
     },
     {
@@ -444,8 +425,7 @@
           "Roboto Mono Light"
         ],
         "text-size": 10
-      },
-      "paint": {}
+      }
     },
     {
       "id": "graticules-lines",
@@ -560,8 +540,7 @@
       "source": "labels",
       "layout": {
         "visibility": "none"
-      },
-      "paint": {}
+      }
     }
   ]
 }

--- a/app/src/map/mapStyleActions.js
+++ b/app/src/map/mapStyleActions.js
@@ -62,6 +62,12 @@ const updateGLLayer = (style, glLayerId, refLayer, reportPolygonsIds) => {
       newStyle = newStyle.setIn(['layers', glLayerIndex, 'paint', 'fill-color'], fillColor);
       break;
     }
+    case 'line': {
+      newStyle = newStyle
+        .setIn(['layers', glLayerIndex, 'paint', 'line-opacity'], refLayer.opacity)
+        .setIn(['layers', glLayerIndex, 'paint', 'line-color'], refLayer.color);
+      break;
+    }
     case 'symbol': {
       // TODO use metadata to set is label, or just use 'symbol' ?
       // if (glLayer.isLabelsLayer === true) {

--- a/app/src/map/mapStyleActions.js
+++ b/app/src/map/mapStyleActions.js
@@ -117,6 +117,34 @@ export const addCustomGLLayer = layerId => (dispatch, getState) => {
   dispatch(updateMapStyle());
 };
 
+const addWorkspaceGLLayers = workspaceGLLayers => (dispatch, getState) => {
+  const state = getState();
+  let style = state.mapStyle.mapStyle;
+
+  workspaceGLLayers.forEach((workspaceGLLayer) => {
+    const id = workspaceGLLayer.id;
+    const gl = workspaceGLLayer.gl;
+    const finalSource = fromJS(gl.source);
+    style = style.setIn(['sources', id], finalSource);
+
+    const layers = [];
+    gl.layers.forEach((srcGlLayer) => {
+      const glLayer = {
+        ...srcGlLayer,
+        source: id,
+        'source-layer': id
+      };
+      layers.push(glLayer);
+    });
+
+    const finalLayers = fromJS(layers);
+    style = style.set('layers', style.get('layers').concat(finalLayers));
+  });
+
+  dispatch(setMapStyle(style));
+  dispatch(updateMapStyle());
+};
+
 const getCartoLayerInstanciatePromise = ({ sourceId, sourceCartoSQL }) => {
   const mapConfig = { layers: [{ id: sourceId, options: { sql: sourceCartoSQL } }] };
   const mapConfigURL = encodeURIComponent(JSON.stringify(mapConfig));
@@ -190,13 +218,21 @@ export const updateMapStyle = () => (dispatch, getState) => {
   let style = state.mapStyle.mapStyle;
   const currentStyle = style.toJS();
   const glLayers = currentStyle.layers;
+  const glSources = currentStyle.sources;
+
+  // collect layers declared in workspace but not in original gl style
+  const workspaceGLLayers = layers.filter(layer => layer.gl !== undefined && glSources[layer.id] === undefined);
+  if (workspaceGLLayers.length) {
+    dispatch(addWorkspaceGLLayers(workspaceGLLayers));
+    return;
+  }
 
   const cartoLayersToInstanciate = [];
 
   for (let i = 0; i < glLayers.length; i++) {
     const glLayer = glLayers[i];
     const sourceId = glLayer.source;
-    const glSource = currentStyle.sources[sourceId];
+    const glSource = glSources[sourceId];
     const layerId = (glLayer.metadata !== undefined && glLayer.metadata['gfw:id']) || sourceId;
 
     const refLayer = layers.find(l => l.id === layerId);

--- a/documentation/workspaces.md
+++ b/documentation/workspaces.md
@@ -2,6 +2,118 @@
 
 ## Workspace parameters
 
+### map:center
+
+A lat, lon pair for the map center.
+
+### map:zoom
+
+The zoom value as a float (non integer values are allowed).
+
+### map:layers
+
+#### type
+
+- `CartoDBAnimation`: static, vector based layers served from a CARTO instance, and rendered by Mapbox GL.
+- `ClusterAnimation`: activity layers, rendered by Pixi.
+
+#### opacity
+
+#### color
+
+#### visible
+
+#### gl
+
+The `gl` parameter allows specifying custom Mapbox GL JSON layers, even if they are not set in the <a href="https://github.com/GlobalFishingWatch/map-client/blob/develop/app/src/map/gl-styles/style.json">base GL JSON</a> style. 
+
+`gl` needs two mandatory parameters:
+- `source`: A source can set a SQL query on a CARTO table <a href="https://github.com/GlobalFishingWatch/map-client/blob/develop/documentation/layers.md#gfwcarto-sql">as described in the layers documentation</a>, as well as the fields displayed in popups. Source id will automatically be set to the workspace layer id.
+- `layers`: One or more GL layers associated to this workspace layer. A vector workspace layer will have typically a GL layer for polygons, and optionally a GL layer for labels. **Important:** the GL `type` (and associated style parameters) must match the corresponding CARTO/PostGIS type, ie: 
+  - Polygons table -> `type: "fill"`
+  - Lines table -> `type: "line"`
+Note: the `source` and `source-layer` are not required as they will be automatically set to the workspace layer id.
+
+For more on available GL layer style options, please refer to the <a href="https://www.mapbox.com/mapbox-gl-js/style-spec/">GL style spec</a>
+
+**Examples**
+
+Simple line layer without labels nor popups:
+```
+{
+  "title":	"Zona Reservada Mar Pacífico Tropical Peruano",
+  "type": "CartoDBAnimation",
+  "id": "mar_pacifico_peruano",
+  "color": "#ff0000",
+  "visible": true,
+  "gl": {
+    "source": {
+      "type": "vector",
+      "metadata": {
+        "gfw:carto-sql": "SELECT * FROM peru_mar_pacifico_tropical"
+      }
+    },
+    "layers": [
+      {
+        "id": "mar_pacifico_peruano",
+        "type": "line",
+        "layout": { 
+          "visibility": "none"
+        },
+        "interactive": true
+      }
+    ]
+  }
+}
+```
+
+Polygon/fill layer with labels and popups:
+
+```
+{
+  "title":	"South American countries",
+  "type": "CartoDBAnimation",
+  "id": "samerica_adm0",
+  "color": "#ff00ff",
+  "visible": true,
+  "gl": {
+    "source": {
+      "type": "vector",
+      "metadata": {
+        "gfw:carto-sql": "SELECT * FROM samerica_adm0",
+        "gfw:popups": [
+          { "id": "name" },
+          { "id": "adm0_a3" },
+          { "id": "POLYGON_LAYERS_AREA" }
+        ]
+      }
+    },
+    "layers": [
+      {
+        "id": "samerica_adm0",
+        "type": "fill",
+        "layout": { 
+          "visibility": "none"
+        },
+        "interactive": true
+      },
+      {
+        "id": "samerica_adm0-labels",
+        "type": "symbol",
+        "layout": {
+          "visibility": "none",
+          "text-field": "{name}",
+          "text-font": [
+            "Roboto Mono Light"
+          ],
+          "text-size": 10
+        }
+      }
+    ]
+  }
+}
+```
+
 ### timeline
 
 ![](https://github.com/Vizzuality/GlobalFishingWatch/blob/develop/documentation/timebar.png?raw=true)
@@ -35,7 +147,9 @@ It's possible to also just set "auto": true, in which case daysEndInnerOuterFrom
 
 ## Workspace Override
 
-As of v1:
+Some parameters of the loaded workspace can be overriden with URL parameters. Either `paramsPlainText` (raw JSON) or `params` (base64/`atob` encoded JSON).
+
+Example (as of v1):
 ```
 {
   vessels: [[seriesgroup/uvi0, tilesetId0, series0], ..., [seriesgroup/uviN, tilesetIdN,seriesN]],  // merges with workspace pinned vessels, first vessel of the array is shownVessel, series is an optional argument for each vessel
@@ -45,6 +159,8 @@ As of v1:
   version: int // the version will tell the client the structure of the params
 }
 ```
+
+### Supported parameters
 
 #### vessels
 

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -2,18 +2,11 @@
   "workspace": {
     "map": {
       "center": [
-        13.833970368737164, -99.8458247347295
+        -15.154322659771124,
+        -76.11053466796875
       ],
-      "zoom": 4,
+      "zoom": 6,
       "layers": [
-        {
-          "title": "europe2",
-          "visible": true,
-          "type": "CartoDBAnimation",
-          "opacity": 1,
-          "id": "europe2",
-          "color": "#ff0000"
-        },
         {
           "title": "mpant",
           "visible": true,
@@ -23,42 +16,82 @@
           "color": "#ffff00"
         },
         {
-          "title": "Fishing effort",
-          "description": "Global Fishing Watch uses data about a vessel’s identity, type, location, speed, direction and more that is broadcast using the Automatic Identification System (AIS) and collected via satellites and terrestrial receivers. AIS was developed for safety/collision-avoidance. Global Fishing Watch analyzes AIS data collected from vessels that our research has identified as known or possible commercial fishing vessels, and applies a fishing detection algorithm to determine “apparent fishing activity” based on changes in vessel speed and direction. The algorithm classifies each AIS broadcast data point for these vessels as either apparently fishing or not fishing and shows the former on the Global Fishing Watch fishing activity heat map. AIS data as broadcast may vary in completeness, accuracy and quality. Also, data collection by satellite or terrestrial receivers may introduce errors through missing or inaccurate data. Global Fishing Watch’s fishing detection algorithm is a best effort mathematically to identify “apparent fishing activity.” As a result, it is possible that some fishing activity is not identified as such by Global Fishing Watch; conversely, Global Fishing Watch may show apparent fishing activity where fishing is not actually taking place. For these reasons, Global Fishing Watch qualifies designations of vessel fishing activity, including synonyms of the term “fishing activity,” such as “fishing” or “fishing effort,” as “apparent,” rather than certain. Any/all Global Fishing Watch information about “apparent fishing activity” should be considered an estimate and must be relied upon solely at your own risk. Global Fishing Watch is taking steps to make sure fishing activity designations are as accurate as possible. Global Fishing Watch fishing detection algorithms are developed and tested using actual fishing event data collected by observers, combined with expert analysis of vessel movement data resulting in the manual classification of thousands of known fishing events. Global Fishing Watch also collaborates extensively with academic researchers through our research program to share fishing activity classification data and automated classification techniques.",
-          "url": "https://api-dot-skytruth-pleuston.appspot.com/v2/tilesets/gfw-tasks-657-uvi-v2",
+          "title":	"Zona Reservada Mar Pacífico Tropical Peruano",
+          "type": "CartoDBAnimation",
+          "id": "mar_pacifico_peruano",
+          "color": "#ff0000",
           "visible": true,
-          "hue": 182,
-          "type": "ClusterAnimation",
-          "opacity": 1,
-          "id": "fishing",
-          "tilesetId": "gfw-tasks-657-uvi-v2",
-          "label": "Fishing effort",
-          "added": true,
-          "library": true,
-          "filterActivated": null
+          "gl": {
+            "source": {
+              "type": "vector",
+              "metadata": {
+                "gfw:carto-sql": "SELECT * FROM peru_mar_pacifico_tropical"
+              }
+            },
+            "layers": [
+              {
+                "id": "mar_pacifico_peruano",
+                "type": "fill",
+                "layout": { 
+                 "visibility": "none"
+                },
+                "interactive": true
+              }
+            ]
+          }
+        },
+        {
+          "title":	"South American countries",
+          "type": "CartoDBAnimation",
+          "id": "samerica_adm0",
+          "color": "#ff00ff",
+          "visible": true,
+          "gl": {
+            "source": {
+              "type": "vector",
+              "metadata": {
+                "gfw:carto-sql": "SELECT * FROM samerica_adm0",
+                "gfw:popups": [
+                  { "id": "name" },
+                  { "id": "adm0_a3" },
+                  { "id": "POLYGON_LAYERS_AREA" }
+                ]
+              }
+            },
+            "layers": [
+              {
+                "id": "samerica_adm0",
+                "type": "fill",
+                "layout": { 
+                 "visibility": "none"
+                },
+                "interactive": true
+              },
+              {
+                "id": "samerica_adm0-labels",
+                "type": "symbol",
+                "layout": {
+                  "visibility": "none",
+                  "text-field": "{name}",
+                  "text-font": [
+                    "Roboto Mono Light"
+                  ],
+                  "text-size": 10
+                }
+              }
+            ]
+          }
         }
       ]
     },
-    "pinnedVessels": [
-      {"seriesgroup":4315970,"tilesetId":"gfw-tasks-657-uvi-v2","title":"OAXACA","visible":true,"color":"#ffff00"},
-      {"seriesgroup":3835805,"tilesetId":"gfw-tasks-657-uvi-v2","title":"AZTECA 5","visible":false,"color":"#00ff6a"},
-      {"seriesgroup":1918314,"tilesetId":"gfw-tasks-657-uvi-v2","title":"GIJON","visible":true,"color":"#fca26f"},
-      {"seriesgroup":1678772,"tilesetId":"gfw-tasks-657-uvi-v2","title":"FU YUAN YU 018","visible":true,"color":"#ff81e5"}
-    ],
-    "fleets": [
-      {
-        "title": "Some boats on the Mexican coast that is a very very very long description",
-        "vessels": [4315970, 3835805],
-        "visible": true,
-        "color": "#00ff6a"
-      }
-    ],
+    "pinnedVessels": [],
+    "fleets": [],
     "encounters": {
       "seriesgroup": null,
       "tilesetId": null
     },
     "basemap": "hybrid",
-    "basemapOptions": ["labels", "graticules"],
+    "basemapOptions": [],
     "timeline": {
       "auto": {
         "daysEndInnerOuterFromToday": 4,

--- a/public/workspace.json
+++ b/public/workspace.json
@@ -31,7 +31,7 @@
             "layers": [
               {
                 "id": "mar_pacifico_peruano",
-                "type": "fill",
+                "type": "line",
                 "layout": { 
                  "visibility": "none"
                 },


### PR DESCRIPTION
This adds the possibility to directly specify Mapbox GL JSON for workspace layers, allowing pulling layers from CARTO without having to have them specified in the `directory` endpoint nor in the base GL JSON style (use cases described here: https://github.com/GlobalFishingWatch/map-client/issues/932#issuecomment-412865322)

The gist of it is: 
- set up a CARTO table, have it public
- add the SQL query and a bunch of other parameters in the workspace layer `gl` parameter.
This is fully documented, with examples, here: https://github.com/GlobalFishingWatch/map-client/blob/a0e6283d539c75048a4cfa9221797f50d14b9b2b/documentation/workspaces.md
This is the workspace used for tests: https://github.com/GlobalFishingWatch/map-client/blob/a0e6283d539c75048a4cfa9221797f50d14b9b2b/public/workspace.json

@enriquetuya I made that choice because:
- this avoids having any conversion/parsing step on the client side code, reducing complexity (GL JSON is just taken from the workspace layer and merged with the base GL JSON style)
- it doesn't require creating a CARTO map/vizjson, only a public table and a SQL query are required.
- this gives complete control over the appeareance and behavior of the custom layer: SQL, popups, labels, various styling attributes, etc.
- from there, allowing custom raster and/or WMS workspace layers should be a breeze.

The disadvantage is that it is slightly more complex than it could be, so let me know if I should clarify anything.