### PR TITLE
Miniglobe viewport outline is now accurate

### DIFF
--- a/app/src/activityLayers/containers/ActivityLayers.js
+++ b/app/src/activityLayers/containers/ActivityLayers.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux';
 import ActivityLayers from 'activityLayers/components/ActivityLayers.jsx';
 import { queryHeatmapVessels } from 'activityLayers/heatmapTilesActions';
+import { exportNativeViewport } from 'map/mapViewportActions';
 
 const mapStateToProps = state => ({
   layers: state.layers.workspaceLayers,
@@ -11,6 +12,8 @@ const mapStateToProps = state => ({
   highlightedClickedVessel: state.heatmap.highlightedClickedVessel,
   viewport: state.mapViewport.viewport,
   zoom: state.mapViewport.viewport.zoom,
+  leftWorldScaled: state.mapViewport.leftWorldScaled,
+  rightWorldScaled: state.mapViewport.rightWorldScaled,
   layerFilters: state.filterGroups.layerFilters,
   vesselTracks: state.vesselInfo.vessels,
   tracks: state.tracks.tracks
@@ -19,6 +22,9 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   queryHeatmapVessels: (coords) => {
     dispatch(queryHeatmapVessels(coords));
+  },
+  exportNativeViewport: (viewport) => {
+    dispatch(exportNativeViewport(viewport));
   }
 });
 

--- a/app/src/config.js
+++ b/app/src/config.js
@@ -196,10 +196,8 @@ export const MINI_GLOBE_SETTINGS = {
   viewBoxHeight: 200,
   svgWidth: 40,
   scale: 100,
-  viewportRatio: 1.1,
-  zoomRatio: 2.4,
   defaultSize: 20,
-  minZoom: 3
+  minZoom: 2.5
 };
 
 export const STATIC_LAYERS_CARTO_ENDPOINT = 'https://carto.globalfishingwatch.org/user/admin/api/v1/map?config=$MAPCONFIG';

--- a/app/src/map/mapViewportReducer.js
+++ b/app/src/map/mapViewportReducer.js
@@ -3,7 +3,8 @@ import {
   UPDATE_VIEWPORT,
   SET_ZOOM_INCREMENT,
   SET_MOUSE_LAT_LONG,
-  TRANSITION_END
+  TRANSITION_END,
+  SET_NATIVE_VIEWPORT
 } from 'map/mapViewportActions';
 
 import { FlyToInterpolator } from 'react-map-gl';
@@ -89,6 +90,10 @@ export default function (state = initialState, action) {
 
     case TRANSITION_END: {
       return { ...state, currentTransition: null };
+    }
+
+    case SET_NATIVE_VIEWPORT: {
+      return { ...state, ...action.payload };
     }
 
     default:

--- a/app/src/miniglobe/components/MiniGlobe.jsx
+++ b/app/src/miniglobe/components/MiniGlobe.jsx
@@ -12,9 +12,7 @@ class MiniGlobe extends Component {
   constructor() {
     super();
     this.state = {
-      projection: null,
-      markerWidth: `${MINI_GLOBE_SETTINGS.defaultSize}px`,
-      markerHeight: `${MINI_GLOBE_SETTINGS.defaultSize}px`
+      projection: null
     };
 
     this.worldData = feature(jsonData, jsonData.objects.land).features;
@@ -22,29 +20,11 @@ class MiniGlobe extends Component {
 
   componentDidMount() {
     this.setProjection();
-    this.setMarkerSize(this.props.zoom, this.props.viewportWidth, this.props.viewportHeight);
   }
 
   componentDidUpdate(nextProps) {
     if (this.props.latitude !== nextProps.latitude || this.props.longitude !== nextProps.longitude) {
       this.recenter();
-    }
-
-    if (this.props.zoom !== nextProps.zoom ||
-        this.props.viewportWidth !== nextProps.viewportWidth ||
-        this.props.viewportHeight !== nextProps.viewportHeight
-    ) {
-      this.changeZoom();
-    }
-  }
-
-  setMarkerSize(zoom, viewportWidth, viewportHeight) {
-    if (zoom && viewportWidth && viewportHeight) {
-      const zoomRelation = MINI_GLOBE_SETTINGS.zoomRatio ** zoom;
-      const markerWidth = `${(viewportWidth * MINI_GLOBE_SETTINGS.viewportRatio) / zoomRelation}px`;
-      const markerHeight = `${(viewportHeight * MINI_GLOBE_SETTINGS.viewportRatio) / zoomRelation}px`;
-
-      this.setState({ markerWidth, markerHeight });
     }
   }
 
@@ -67,23 +47,13 @@ class MiniGlobe extends Component {
     }
   }
 
-  changeZoom() {
-    const { zoom, viewportWidth, viewportHeight } = this.props;
-    if (zoom && viewportWidth && viewportHeight) {
-      this.setMarkerSize(zoom, viewportWidth, viewportHeight);
-    }
-  }
-
   render() {
-    const { zoom } = this.props;
-    const { markerHeight, markerWidth } = this.state;
+    const { zoom, viewportBoundsGeoJSON } = this.props;
     const { svgWidth, viewBoxX, viewBoxY, viewBoxWidth, viewBoxHeight } = MINI_GLOBE_SETTINGS;
+
     return (
-      <div id="miniGlobe" className={MiniGlobeStyles.miniGlobe}>
+      <div className={MiniGlobeStyles.miniGlobe}>
         <div className={MiniGlobeStyles.svgContainer} >
-          { zoom > MINI_GLOBE_SETTINGS.minZoom &&
-            <div className={MiniGlobeStyles.zoneMarker} style={{ width: markerWidth, height: markerHeight }} />
-          }
           <svg
             width={svgWidth}
             height={svgWidth}
@@ -96,9 +66,15 @@ class MiniGlobe extends Component {
                   <path
                     key={`path-${i}`}
                     d={geoPath().projection(this.state.projection)(d)}
-                    className="land"
                   />
                 ))
+              }
+              { zoom > MINI_GLOBE_SETTINGS.minZoom &&
+                <path
+                  key="viewport"
+                  d={geoPath().projection(this.state.projection)(viewportBoundsGeoJSON)}
+                  className={MiniGlobeStyles.viewport}
+                />
               }
             </g>
           </svg>
@@ -117,8 +93,7 @@ MiniGlobe.propTypes = {
   latitude: PropTypes.number.isRequired,
   longitude: PropTypes.number.isRequired,
   zoom: PropTypes.number.isRequired,
-  viewportWidth: PropTypes.number,
-  viewportHeight: PropTypes.number
+  viewportBoundsGeoJSON: PropTypes.object
 };
 
 export default MiniGlobe;

--- a/app/src/miniglobe/components/miniGlobe.scss
+++ b/app/src/miniglobe/components/miniGlobe.scss
@@ -18,14 +18,6 @@
     display: flex;
     justify-content: center;
 
-    .zoneMarker {
-      border: 2px solid red;
-      position: absolute;
-      z-index: 10;
-      flex: 1;
-      align-self: center;
-    }
-
     .globeSvg {
       position: absolute;
       fill: $color-base;
@@ -34,4 +26,10 @@
       border-radius: 50%;
     }
   }
+}
+
+.viewport {
+  stroke-width: 6px;
+  fill: none;
+  stroke: red;
 }

--- a/app/src/miniglobe/containers/MiniGlobe.js
+++ b/app/src/miniglobe/containers/MiniGlobe.js
@@ -5,8 +5,7 @@ const mapStateToProps = state => ({
   latitude: state.mapViewport.viewport.latitude,
   longitude: state.mapViewport.viewport.longitude,
   zoom: state.mapViewport.viewport.zoom,
-  viewportWidth: state.mapViewport.viewport.width,
-  viewportHeight: state.mapViewport.viewport.height
+  viewportBoundsGeoJSON: state.mapViewport.viewportBoundsGeoJSON
 });
 
 export default connect(mapStateToProps)(MiniGlobe);


### PR DESCRIPTION
Miniglobe viewport outline (red polygon) used to be an approximation; it is now fully accurate, taking projection into account.

Fixes an issue mentioned here:
https://github.com/GlobalFishingWatch/map-client/issues/941

![fishing-miniglobe](https://user-images.githubusercontent.com/1583415/44264883-89d8a880-a224-11e8-8718-b293a0961c15.gif)
