### PR TITLE
Fit to track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+- Added a button to fit the viewport and timebar to vessel tracks
+- Removed automatic fit to viewport and timebar when clicking on a vessel search result (can now be done by explicitely clicking the button)
+- Clicking the (i) vessel button again now hides vessel details
+- Harmonisation of icons
+
 ## 3.0.0
 - Allow custom Mapbox GL JSON style in workspaces (https://github.com/GlobalFishingWatch/map-client/pull/943)
 - Deeper zoom levels up to 14, even when activity layer tiles are not visible (https://github.com/GlobalFishingWatch/map-client/pull/942)

--- a/app/assets/icons/target.svg
+++ b/app/assets/icons/target.svg
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="15px" height="15px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 51.2 (57519) - http://www.bohemiancoding.com/sketch -->
-    <title>locate</title>
-    <desc>Created with Sketch.</desc>
+    <title>Fit map to vessel tracks</title>
     <defs></defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="new---monthly---two-vessels" transform="translate(-1183.000000, -141.000000)" fill="#46A4BC" fill-rule="nonzero">

--- a/app/src/components/Shared/Icon.jsx
+++ b/app/src/components/Shared/Icon.jsx
@@ -14,6 +14,9 @@ import Reports from '-!babel-loader!svg-react-loader!assets/icons/report-menu.sv
 import Layers from '-!babel-loader!svg-react-loader!assets/icons/layers-menu.svg';
 import Filters from '-!babel-loader!svg-react-loader!assets/icons/filters-menu.svg';
 import Report from '-!babel-loader!svg-react-loader!assets/icons/report.svg';
+import Target from '-!babel-loader!svg-react-loader!assets/icons/target.svg';
+import Pin from '-!babel-loader!svg-react-loader!assets/icons/pin.svg';
+import Unpin from '-!babel-loader!svg-react-loader!assets/icons/unpin.svg';
 
 class Icon extends Component {
   render() {
@@ -33,6 +36,9 @@ class Icon extends Component {
       case 'layers': iconElement = <Layers className={classNames} />; break;
       case 'filters': iconElement = <Filters className={classNames} />; break;
       case 'report': iconElement = <Report className={classnames(classNames, IconStyles.report)} />; break;
+      case 'target': iconElement = <Target className={classNames} />; break;
+      case 'pin': iconElement = <Pin className={classnames(classNames, IconStyles.pin)} />; break;
+      case 'unpin': iconElement = <Unpin className={classNames} />; break;
       default:
         console.warn('that icon does not exist', icon);
         iconElement = null;

--- a/app/src/components/Shared/Icon.scss
+++ b/app/src/components/Shared/Icon.scss
@@ -32,3 +32,7 @@
     }
   }
 }
+
+.pin {
+  transform: translate(-1px, 0);
+}

--- a/app/src/components/Shared/IconButton.jsx
+++ b/app/src/components/Shared/IconButton.jsx
@@ -6,9 +6,14 @@ import IconButtonStyles from 'src/components/Shared/IconButton.scss';
 
 class IconButton extends Component {
   render() {
-    const { icon, activated, label } = this.props;
+    const { icon, activated, disabled, label } = this.props;
     return (<div>
-      <button className={classnames(IconButtonStyles.iconButton, { [IconButtonStyles._activated]: activated })}>
+      <button
+        className={classnames(IconButtonStyles.iconButton, {
+          [IconButtonStyles._activated]: activated,
+          [IconButtonStyles._disabled]: disabled
+        })}
+      >
         <Icon icon={icon} activated={activated} />
       </button>
       {label !== undefined && <span className={IconButtonStyles.label}>
@@ -21,7 +26,8 @@ class IconButton extends Component {
 IconButton.propTypes = {
   icon: PropTypes.string,
   label: PropTypes.string,
-  activated: PropTypes.bool
+  activated: PropTypes.bool,
+  disabled: PropTypes.bool
 };
 
 export default IconButton;

--- a/app/src/components/Shared/IconButton.scss
+++ b/app/src/components/Shared/IconButton.scss
@@ -16,6 +16,11 @@
   &._activated {
     background-color: $color-31;
   }
+
+  &._disabled {
+    opacity: .5;
+    pointer-events: none;
+  }
 }
 
 .label {

--- a/app/src/encounters/components/EncountersVessel.jsx
+++ b/app/src/encounters/components/EncountersVessel.jsx
@@ -28,7 +28,7 @@ function EncountersVessel({ vessel, userPermissions, login, openVessel }) {
 
   return (
     <div className={infoPanelStyles.encountersData} >
-      <VesselInfoDetails currentlyShownVessel={vessel.info} layerFieldsHeaders={fields} userPermissions={userPermissions}>
+      <VesselInfoDetails vesselInfo={vessel.info} layerFieldsHeaders={fields} userPermissions={userPermissions}>
         <div className={infoPanelStyles.rowInfo} >
           <span className={infoPanelStyles.key} >Vessel</span>
           <a onClick={() => openVessel(vessel)} className={classnames(infoPanelStyles.value, infoPanelStyles.arrowLink)} >

--- a/app/src/map/mapInteractionActions.js
+++ b/app/src/map/mapInteractionActions.js
@@ -220,7 +220,11 @@ export const mapClick = (latitude, longitude, features) => (dispatch, getState) 
       } else {
         const idFieldKey = (layer.header.info.id === undefined) ? 'seriesgroup' : layer.header.info.id;
         const id = foundVessels[0][idFieldKey];
-        dispatch(addVessel(layer.tilesetId, id, selectedSeries));
+        dispatch(addVessel({
+          tilesetId: layer.tilesetId,
+          seriesgroup: id,
+          series: selectedSeries
+        }));
       }
     }
   }

--- a/app/src/map/mapViewportActions.js
+++ b/app/src/map/mapViewportActions.js
@@ -63,25 +63,9 @@ export const zoomIntoVesselCenter = (latitude, longitude) => (dispatch) => {
   dispatch(updateZoom(CLUSTER_CLICK_ZOOM_INCREMENT, latitude, longitude));
 };
 
-export const fitBoundsToTrack = trackData => (dispatch, getState) => {
-  const minLat = Math.min.apply(null, trackData.latitude);
-  const maxLat = Math.max.apply(null, trackData.latitude);
-  let minLng = Math.min.apply(null, trackData.longitude);
-  let maxLng = Math.max.apply(null, trackData.longitude);
-
-  // track crosses the antimeridian
-  if (maxLng - minLng > 350) {
-    const offsetedLngs = trackData.longitude.map((l) => {
-      if (l < 0) {
-        return l + 360;
-      }
-      return l;
-    });
-    minLng = Math.min.apply(null, offsetedLngs);
-    maxLng = Math.max.apply(null, offsetedLngs);
-  }
+export const fitBoundsToTrack = trackBounds => (dispatch, getState) => {
   const vp = fitBounds({
-    bounds: [[minLng, minLat], [maxLng, maxLat]],
+    bounds: [[trackBounds.minLng, trackBounds.minLat], [trackBounds.maxLng, trackBounds.maxLat]],
     width: getState().mapViewport.viewport.width,
     height: getState().mapViewport.viewport.height,
     padding: 50

--- a/app/src/recentVessels/containers/RecentVesselItem.js
+++ b/app/src/recentVessels/containers/RecentVesselItem.js
@@ -10,7 +10,11 @@ const mapDispatchToProps = dispatch => ({
     dispatch(trackRecentVesselAdded());
     dispatch(toggleLayerVisibility(vesselDetails.tilesetId, true));
     dispatch(clearVesselInfo());
-    dispatch(addVessel(vesselDetails.tilesetId, vesselDetails.seriesgroup, null, true, true));
+    dispatch(addVessel({
+      tilesetId: vesselDetails.tilesetId,
+      seriesgroup: vesselDetails.seriesgroup,
+      fromSearch: true
+    }));
   },
   closeRecentVesselModal: () => {
     dispatch(setRecentVesselsModalVisibility(false));

--- a/app/src/recentVessels/containers/RecentVesselsModal.js
+++ b/app/src/recentVessels/containers/RecentVesselsModal.js
@@ -16,7 +16,11 @@ const mapDispatchToProps = dispatch => ({
   drawVessel: (tilesetId, seriesgroup, series) => {
     dispatch(toggleLayerVisibility(tilesetId, true));
     dispatch(clearVesselInfo());
-    dispatch(addVessel(tilesetId, seriesgroup, series, true));
+    dispatch(addVessel({
+      tilesetId,
+      seriesgroup,
+      series
+    }));
     dispatch(setRecentVesselsModalVisibility(false));
   }
 });

--- a/app/src/search/containers/SearchResult.js
+++ b/app/src/search/containers/SearchResult.js
@@ -11,7 +11,11 @@ const mapDispatchToProps = dispatch => ({
   drawVessel: (vesselDetails) => {
     dispatch(toggleLayerVisibility(vesselDetails.tilesetId, true));
     dispatch(clearVesselInfo());
-    dispatch(addVessel(vesselDetails.tilesetId, vesselDetails.seriesgroup, null, true, true));
+    dispatch(addVessel({
+      tilesetId: vesselDetails.tilesetId,
+      seriesgroup: vesselDetails.seriesgroup,
+      fromSearch: true
+    }));
   }
 });
 

--- a/app/src/vesselInfo/components/VesselInfoDetails.jsx
+++ b/app/src/vesselInfo/components/VesselInfoDetails.jsx
@@ -9,10 +9,10 @@ import infoPanelStyles from 'styles/components/info-panel.scss';
 class VesselInfoDetails extends Component {
 
   render() {
-    const { currentlyShownVessel, layerFieldsHeaders, userPermissions } = this.props;
+    const { vesselInfo, layerFieldsHeaders, userPermissions } = this.props;
     const canSeeVesselDetails = (userPermissions !== null && userPermissions.indexOf('info') !== -1);
 
-    const renderedFieldList = this.generateVesselDetails(layerFieldsHeaders, canSeeVesselDetails, currentlyShownVessel);
+    const renderedFieldList = this.generateVesselDetails(layerFieldsHeaders, canSeeVesselDetails, vesselInfo);
 
     return (
       <div className={infoPanelStyles.details}>
@@ -104,7 +104,7 @@ class VesselInfoDetails extends Component {
 
 VesselInfoDetails.propTypes = {
   layerFieldsHeaders: PropTypes.array,
-  currentlyShownVessel: PropTypes.object,
+  vesselInfo: PropTypes.object,
   userPermissions: PropTypes.array,
   children: PropTypes.node
 };

--- a/app/src/vesselInfo/components/VesselInfoPanel.jsx
+++ b/app/src/vesselInfo/components/VesselInfoPanel.jsx
@@ -8,8 +8,8 @@ import infoPanelStyles from 'styles/components/info-panel.scss';
 import buttonCloseStyles from 'styles/components/button-close.scss';
 import iconStyles from 'styles/icons.scss';
 
+import IconButton from 'src/components/Shared/IconButton';
 import CloseIcon from '-!babel-loader!svg-react-loader!assets/icons/close.svg?name=Icon';
-import PinIcon from '-!babel-loader!svg-react-loader!assets/icons/pin.svg?name=PinIcon';
 
 import { INFO_STATUS } from 'constants';
 
@@ -55,23 +55,26 @@ class VesselInfoPanel extends Component {
       vesselInfoContents = (
         <div className={infoPanelStyles.metadata} >
           <VesselInfoDetails {...this.props} />
-          {((
-            this.props.userPermissions !== null &&
-            this.props.userPermissions.indexOf('pin-vessel') !== -1 &&
-            this.props.layerIsPinable
-          ) || vesselInfo.pinned)
-          &&
-            <PinIcon
-              className={classnames(iconStyles.icon, iconStyles.pinIcon,
-                infoPanelStyles.pinIcon, { [`${infoPanelStyles._pinned}`]: vesselInfo.pinned })}
-              onClick={() => {
-                this.props.onTogglePin(vesselInfo.seriesgroup);
-              }}
-            />
-          }
-          {(vesselInfo.hasTrack === true) &&
-          <button onClick={this.props.targetVessel}>target</button>
-          }
+
+          <div className={infoPanelStyles.actionIcons}>
+            {((
+              this.props.userPermissions !== null &&
+              this.props.userPermissions.indexOf('pin-vessel') !== -1 &&
+              this.props.layerIsPinable
+            ) || vesselInfo.pinned)
+            &&
+              <div
+                onClick={() => { this.props.onTogglePin(vesselInfo.seriesgroup); }}
+              >
+                <IconButton icon="pin" activated={vesselInfo.pinned} />
+              </div>
+            }
+
+            <div onClick={this.props.targetVessel}>
+              <IconButton icon="target" disabled={vesselInfo.hasTrack !== true} />
+            </div>
+          </div>
+
           {canSeeVesselDetails && vesselInfo.mmsi && <a
             className={infoPanelStyles.externalLink}
             target="_blank"

--- a/app/src/vesselInfo/components/VesselInfoPanel.jsx
+++ b/app/src/vesselInfo/components/VesselInfoPanel.jsx
@@ -70,6 +70,7 @@ class VesselInfoPanel extends Component {
               }}
             />
           }
+          <button onClick={this.props.targetVessel}>target</button>
           {canSeeVesselDetails && vesselInfo.mmsi && <a
             className={infoPanelStyles.externalLink}
             target="_blank"
@@ -136,7 +137,8 @@ VesselInfoPanel.propTypes = {
   hide: PropTypes.func,
   onTogglePin: PropTypes.func,
   login: PropTypes.func,
-  showParentEncounter: PropTypes.func
+  showParentEncounter: PropTypes.func,
+  targetVessel: PropTypes.func
 };
 
 export default VesselInfoPanel;

--- a/app/src/vesselInfo/components/VesselInfoPanel.jsx
+++ b/app/src/vesselInfo/components/VesselInfoPanel.jsx
@@ -33,8 +33,7 @@ class VesselInfoPanel extends Component {
   }
 
   render() {
-    const vesselInfo = this.props.currentlyShownVessel;
-    const status = this.props.infoPanelStatus;
+    const { vesselInfo, status } = this.props;
 
     if (status !== INFO_STATUS.LOADING && vesselInfo === null) {
       return null;
@@ -70,7 +69,9 @@ class VesselInfoPanel extends Component {
               }}
             />
           }
+          {(vesselInfo.hasTrack === true) &&
           <button onClick={this.props.targetVessel}>target</button>
+          }
           {canSeeVesselDetails && vesselInfo.mmsi && <a
             className={infoPanelStyles.externalLink}
             target="_blank"
@@ -129,10 +130,10 @@ class VesselInfoPanel extends Component {
 }
 
 VesselInfoPanel.propTypes = {
-  currentlyShownVessel: PropTypes.object,
+  vesselInfo: PropTypes.object,
   layerFieldsHeaders: PropTypes.array,
   layerIsPinable: PropTypes.bool,
-  infoPanelStatus: PropTypes.number,
+  status: PropTypes.number,
   userPermissions: PropTypes.array,
   hide: PropTypes.func,
   onTogglePin: PropTypes.func,

--- a/app/src/vesselInfo/containers/VesselInfoPanel.js
+++ b/app/src/vesselInfo/containers/VesselInfoPanel.js
@@ -5,8 +5,9 @@ import { setEncountersInfo } from 'encounters/encountersActions';
 import { login } from 'user/userActions';
 
 const mapStateToProps = (state) => {
+  const vesselInfo = state.vesselInfo.currentlyShownVessel;
   const currentlyShownLayer = state.layers.workspaceLayers
-    .find(layer => state.vesselInfo.currentlyShownVessel && layer.tilesetId === state.vesselInfo.currentlyShownVessel.tilesetId);
+    .find(layer => vesselInfo && layer.tilesetId === vesselInfo.tilesetId);
 
   let layerFieldsHeaders;
   let layerIsPinable = true;
@@ -22,10 +23,10 @@ const mapStateToProps = (state) => {
   }
 
   return {
-    currentlyShownVessel: state.vesselInfo.currentlyShownVessel,
+    vesselInfo,
     layerFieldsHeaders,
     layerIsPinable,
-    infoPanelStatus: state.vesselInfo.infoPanelStatus,
+    status: state.vesselInfo.infoPanelStatus,
     userPermissions: state.user.userPermissions
   };
 };

--- a/app/src/vesselInfo/containers/VesselInfoPanel.js
+++ b/app/src/vesselInfo/containers/VesselInfoPanel.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import VesselInfoPanel from 'vesselInfo/components/VesselInfoPanel';
-import { clearVesselInfo, toggleActiveVesselPin } from 'vesselInfo/vesselInfoActions';
+import { clearVesselInfo, toggleActiveVesselPin, targetCurrentlyShownVessel } from 'vesselInfo/vesselInfoActions';
 import { setEncountersInfo } from 'encounters/encountersActions';
 import { login } from 'user/userActions';
 
@@ -43,7 +43,11 @@ const mapDispatchToProps = dispatch => ({
   showParentEncounter: (encounter) => {
     dispatch(clearVesselInfo());
     dispatch(setEncountersInfo(encounter.seriesgroup, encounter.tilesetId));
+  },
+  targetVessel: () => {
+    dispatch(targetCurrentlyShownVessel());
   }
+
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(VesselInfoPanel);

--- a/app/src/vesselInfo/containers/VesselInfoPanel.js
+++ b/app/src/vesselInfo/containers/VesselInfoPanel.js
@@ -47,7 +47,6 @@ const mapDispatchToProps = dispatch => ({
   targetVessel: () => {
     dispatch(targetCurrentlyShownVessel());
   }
-
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(VesselInfoPanel);

--- a/app/src/vesselInfo/vesselInfoActions.js
+++ b/app/src/vesselInfo/vesselInfoActions.js
@@ -438,9 +438,13 @@ export function showPinnedVesselDetails(tilesetId, seriesgroup) {
   };
 }
 
-export const targetCurrentlyShownVessel = () => (dispatch, getState) => {
-  const seriesgroup = getState().vesselInfo.currentlyShownVessel.seriesgroup;
+export const targetVessel = seriesgroup => (dispatch, getState) => {
   const vessel = getState().vesselInfo.vessels.find(v => v.seriesgroup === seriesgroup);
   dispatch(fitBoundsToTrack(vessel.track.geoBounds));
   dispatch(fitTimelineToTrack(vessel.track.timelineBounds));
+};
+
+export const targetCurrentlyShownVessel = () => (dispatch, getState) => {
+  const seriesgroup = getState().vesselInfo.currentlyShownVessel.seriesgroup;
+  dispatch(targetVessel(seriesgroup));
 };

--- a/app/src/vesselInfo/vesselInfoActions.js
+++ b/app/src/vesselInfo/vesselInfoActions.js
@@ -431,10 +431,18 @@ export function togglePinnedVesselEditMode(forceMode = null) {
   };
 }
 
-export function showPinnedVesselDetails(tilesetId, seriesgroup) {
-  return (dispatch) => {
-    dispatch(showVesselDetails(tilesetId, seriesgroup));
-    dispatch(togglePinnedVesselVisibility(seriesgroup, true));
+export function togglePinnedVesselDetails(seriesgroup, label, tilesetId) {
+  return (dispatch, getState) => {
+    const hide = getState().vesselInfo.currentlyShownVessel
+      && getState().vesselInfo.currentlyShownVessel.seriesgroup === seriesgroup;
+
+    if (hide === true) {
+      dispatch(clearVesselInfo());
+    } else {
+      dispatch(addVesselToRecentVesselList(seriesgroup, label, tilesetId));
+      dispatch(togglePinnedVesselVisibility(seriesgroup, true));
+      dispatch(showVesselDetails(tilesetId, seriesgroup));
+    }
   };
 }
 

--- a/app/src/vesselInfo/vesselInfoActions.js
+++ b/app/src/vesselInfo/vesselInfoActions.js
@@ -113,7 +113,7 @@ function _getTrackTimeExtent(data, series = null) {
   return [start, end];
 }
 
-export function getVesselTrack({ tilesetId, seriesgroup, series, zoomToBounds, updateTimelineBounds }) {
+export function getVesselTrack({ tilesetId, seriesgroup, series, updateTimelineBounds }) {
   return (dispatch, getState) => {
     const state = getState();
 
@@ -154,14 +154,14 @@ export function getVesselTrack({ tilesetId, seriesgroup, series, zoomToBounds, u
           }
         });
 
-        if (updateTimelineBounds === true) {
-          const tracksExtent = _getTrackTimeExtent(groupedData, series);
-          dispatch(fitTimelineToTrack(tracksExtent));
-        }
+        // if (updateTimelineBounds === true) {
+        //   const tracksExtent = _getTrackTimeExtent(groupedData, series);
+        //   dispatch(fitTimelineToTrack(tracksExtent));
+        // }
 
-        if (zoomToBounds) {
-          dispatch(fitBoundsToTrack(groupedData));
-        }
+        // if (zoomToBounds) {
+        //   dispatch(fitBoundsToTrack(groupedData));
+        // }
       });
   };
 }
@@ -303,7 +303,13 @@ export function hideVesselsInfoPanel() {
   };
 }
 
-export function addVessel(tilesetId, seriesgroup, series = null, zoomToBounds = false, fromSearch = false, parentEncounter = null) {
+export function addVessel({
+  tilesetId,
+  seriesgroup,
+  series = null,
+  fromSearch = false,
+  parentEncounter = null
+}) {
   return (dispatch, getState) => {
     const state = getState();
     dispatch({
@@ -323,9 +329,8 @@ export function addVessel(tilesetId, seriesgroup, series = null, zoomToBounds = 
     dispatch(getVesselTrack({
       tilesetId,
       seriesgroup,
-      series,
-      zoomToBounds,
-      updateTimelineBounds: fromSearch === true
+      series
+      // updateTimelineBounds: fromSearch === true
     }));
   };
 }
@@ -333,11 +338,15 @@ export function addVessel(tilesetId, seriesgroup, series = null, zoomToBounds = 
 export function addVesselFromEncounter(tilesetId, seriesgroup) {
   return (dispatch, getState) => {
     const state = getState();
-    const encounter = {
+    const parentEncounter = {
       seriesgroup: state.encounters.seriesgroup,
       tilesetId: state.encounters.tilesetId
     };
-    dispatch(addVessel(tilesetId, seriesgroup, null, false, false, encounter));
+    dispatch(addVessel({
+      tilesetId,
+      seriesgroup,
+      parentEncounter
+    }));
   };
 }
 

--- a/app/src/vesselInfo/vesselInfoActions.js
+++ b/app/src/vesselInfo/vesselInfoActions.js
@@ -28,6 +28,59 @@ export const TOGGLE_PINNED_VESSEL_EDIT_MODE = 'TOGGLE_PINNED_VESSEL_EDIT_MODE';
 export const SET_PINNED_VESSEL_TRACK_VISIBILITY = 'SET_PINNED_VESSEL_TRACK_VISIBILITY';
 
 
+const getTrackBounds = (data, series = null, addOffset = false) => {
+  const time = {
+    start: Infinity,
+    end: 0
+  };
+  const geo = {
+    minLat: Infinity,
+    maxLat: -Infinity,
+    minLng: Infinity,
+    maxLng: -Infinity
+  };
+  for (let i = 0, length = data.datetime.length; i < length; i++) {
+    if (series !== null && series !== data.series[i]) {
+      continue;
+    }
+    const datetime = data.datetime[i];
+    if (datetime < time.start) {
+      time.start = datetime;
+    } else if (datetime > time.end) {
+      time.end = datetime;
+    }
+
+    const lat = data.latitude[i];
+    if (lat < geo.minLat) {
+      geo.minLat = lat;
+    } else if (lat > geo.maxLat) {
+      geo.maxLat = lat;
+    }
+
+    let lng = data.longitude[i];
+    if (addOffset === true) {
+      if (lng < 0) {
+        lng += 360;
+      }
+    }
+    if (lng < geo.minLng) {
+      geo.minLng = lng;
+    } else if (lng > geo.maxLng) {
+      geo.maxLng = lng;
+    }
+  }
+
+  // track crosses the antimeridian
+  if (geo.maxLng - geo.minLng > 350 && addOffset === false) {
+    return getTrackBounds(data, series, true);
+  }
+
+  return {
+    time: [time.start, time.end],
+    geo
+  };
+};
+
 function showVesselDetails(tilesetId, seriesgroup) {
   return {
     type: SHOW_VESSEL_DETAILS,
@@ -96,24 +149,8 @@ function setCurrentVessel(tilesetId, seriesgroup, fromSearch) {
   };
 }
 
-function _getTrackTimeExtent(data, series = null) {
-  let start = Infinity;
-  let end = 0;
-  for (let i = 0, length = data.datetime.length; i < length; i++) {
-    if (series !== null && series !== data.series[i]) {
-      continue;
-    }
-    const time = data.datetime[i];
-    if (time < start) {
-      start = time;
-    } else if (time > end) {
-      end = time;
-    }
-  }
-  return [start, end];
-}
 
-export function getVesselTrack({ tilesetId, seriesgroup, series, updateTimelineBounds }) {
+export function getVesselTrack({ tilesetId, seriesgroup, series }) {
   return (dispatch, getState) => {
     const state = getState();
 
@@ -133,7 +170,7 @@ export function getVesselTrack({ tilesetId, seriesgroup, series, updateTimelineB
         if (!cleanData.length) {
           return;
         }
-        const groupedData = groupData(cleanData, [
+        const rawTrackData = groupData(cleanData, [
           'latitude',
           'longitude',
           'datetime',
@@ -142,26 +179,20 @@ export function getVesselTrack({ tilesetId, seriesgroup, series, updateTimelineB
           'sigma'
         ]);
 
-        const vectorArray = addTracksPointsRenderingData(groupedData);
+        const vectorArray = addTracksPointsRenderingData(rawTrackData);
+        const bounds = getTrackBounds(rawTrackData, series);
 
         dispatch({
           type: SET_VESSEL_TRACK,
           payload: {
             seriesgroup,
             data: getTracksPlaybackData(vectorArray),
-            series: uniq(groupedData.series),
+            series: uniq(rawTrackData.series),
+            geoBounds: bounds.geo,
+            timelineBounds: bounds.time,
             selectedSeries: series
           }
         });
-
-        // if (updateTimelineBounds === true) {
-        //   const tracksExtent = _getTrackTimeExtent(groupedData, series);
-        //   dispatch(fitTimelineToTrack(tracksExtent));
-        // }
-
-        // if (zoomToBounds) {
-        //   dispatch(fitBoundsToTrack(groupedData));
-        // }
       });
   };
 }
@@ -330,7 +361,6 @@ export function addVessel({
       tilesetId,
       seriesgroup,
       series
-      // updateTimelineBounds: fromSearch === true
     }));
   };
 }
@@ -408,3 +438,9 @@ export function showPinnedVesselDetails(tilesetId, seriesgroup) {
   };
 }
 
+export const targetCurrentlyShownVessel = () => (dispatch, getState) => {
+  const seriesgroup = getState().vesselInfo.currentlyShownVessel.seriesgroup;
+  const vessel = getState().vesselInfo.vessels.find(v => v.seriesgroup === seriesgroup);
+  dispatch(fitBoundsToTrack(vessel.track.geoBounds));
+  dispatch(fitTimelineToTrack(vessel.track.timelineBounds));
+};

--- a/app/src/vesselInfo/vesselInfoReducer.js
+++ b/app/src/vesselInfo/vesselInfoReducer.js
@@ -70,8 +70,15 @@ export default function (state = initialState, action) {
       const newVessel = Object.assign({}, state.vessels[vesselIndex]);
       newVessel.track = { ...action.payload };
 
+      let currentlyShownVessel = state.currentlyShownVessel;
+      if (newVessel.seriesgroup === currentlyShownVessel.seriesgroup && newVessel.tilesetId === currentlyShownVessel.tilesetId) {
+        currentlyShownVessel = Object.assign({}, currentlyShownVessel);
+        currentlyShownVessel.hasTrack = true;
+      }
+
       return Object.assign({}, state, {
-        vessels: [...state.vessels.slice(0, vesselIndex), newVessel, ...state.vessels.slice(vesselIndex + 1)]
+        vessels: [...state.vessels.slice(0, vesselIndex), newVessel, ...state.vessels.slice(vesselIndex + 1)],
+        currentlyShownVessel
       });
     }
 

--- a/app/src/vesselInfo/vesselInfoReducer.js
+++ b/app/src/vesselInfo/vesselInfoReducer.js
@@ -68,10 +68,7 @@ export default function (state = initialState, action) {
     case SET_VESSEL_TRACK: {
       const vesselIndex = state.vessels.findIndex(vessel => vessel.seriesgroup === action.payload.seriesgroup);
       const newVessel = Object.assign({}, state.vessels[vesselIndex]);
-      newVessel.track = {
-        data: action.payload.data,
-        selectedSeries: action.payload.selectedSeries
-      };
+      newVessel.track = { ...action.payload };
 
       return Object.assign({}, state, {
         vessels: [...state.vessels.slice(0, vesselIndex), newVessel, ...state.vessels.slice(vesselIndex + 1)]

--- a/app/src/vessels/components/Vessel.jsx
+++ b/app/src/vessels/components/Vessel.jsx
@@ -58,13 +58,16 @@ class Vessel extends Component {
         >
           {vessel.title}
         </div>
-        {isEditable && <div onClick={() => this.props.delete(vessel.seriesgroup)}>
+        {isEditable &&
+        <div onClick={() => this.props.delete(vessel.seriesgroup)}>
           <IconButton icon="remove" />
         </div>}
+        {vessel.track !== undefined &&
         <div onClick={() => this.props.targetVessel(vessel.seriesgroup)}>
           <IconButton icon="info" />
-        </div>
-        {isEditable && <div onClick={() => this.toggleExpand()} style={{ position: 'relative' }}>
+        </div>}
+        {isEditable &&
+        <div onClick={() => this.toggleExpand()} style={{ position: 'relative' }}>
           <ExpandableIconButton activated={this.state.expanded === true} >
             <IconButton icon="paint" activated={this.state.expanded === true} />
           </ExpandableIconButton>

--- a/app/src/vessels/components/Vessel.jsx
+++ b/app/src/vessels/components/Vessel.jsx
@@ -51,7 +51,7 @@ class Vessel extends Component {
         </div>
         <div
           className={VesselStyles.title}
-          onClick={() => this.props.showVesselDetails(vessel.seriesgroup)}
+          onClick={() => this.props.togglePinnedVesselDetails(vessel.seriesgroup)}
           data-tip={tooltip}
           data-place="left"
           data-class={TooltipStyles.tooltip}
@@ -71,7 +71,7 @@ class Vessel extends Component {
             <IconButton icon="paint" activated={this.state.expanded === true} />
           </ExpandableIconButton>
         </div>}
-        <div onClick={() => this.props.showVesselDetails(vessel.seriesgroup)}>
+        <div onClick={() => this.props.togglePinnedVesselDetails(vessel.seriesgroup)}>
           <IconButton icon="info" activated={detailsCurrentlyShown} />
         </div>
       </div>
@@ -92,7 +92,7 @@ Vessel.propTypes = {
   editable: PropTypes.bool,
   tall: PropTypes.bool,
   toggle: PropTypes.func,
-  showVesselDetails: PropTypes.func,
+  togglePinnedVesselDetails: PropTypes.func,
   delete: PropTypes.func,
   setColor: PropTypes.func,
   targetVessel: PropTypes.func

--- a/app/src/vessels/components/Vessel.jsx
+++ b/app/src/vessels/components/Vessel.jsx
@@ -61,6 +61,9 @@ class Vessel extends Component {
         {isEditable && <div onClick={() => this.props.delete(vessel.seriesgroup)}>
           <IconButton icon="remove" />
         </div>}
+        <div onClick={() => this.props.targetVessel(vessel.seriesgroup)}>
+          <IconButton icon="info" />
+        </div>
         {isEditable && <div onClick={() => this.toggleExpand()} style={{ position: 'relative' }}>
           <ExpandableIconButton activated={this.state.expanded === true} >
             <IconButton icon="paint" activated={this.state.expanded === true} />
@@ -89,7 +92,8 @@ Vessel.propTypes = {
   toggle: PropTypes.func,
   showVesselDetails: PropTypes.func,
   delete: PropTypes.func,
-  setColor: PropTypes.func
+  setColor: PropTypes.func,
+  targetVessel: PropTypes.func
 };
 
 export default Vessel;

--- a/app/src/vessels/components/Vessel.jsx
+++ b/app/src/vessels/components/Vessel.jsx
@@ -60,12 +60,11 @@ class Vessel extends Component {
         </div>
         {isEditable &&
         <div onClick={() => this.props.delete(vessel.seriesgroup)}>
-          <IconButton icon="remove" />
+          <IconButton icon="unpin" />
         </div>}
-        {vessel.track !== undefined &&
         <div onClick={() => this.props.targetVessel(vessel.seriesgroup)}>
-          <IconButton icon="info" />
-        </div>}
+          <IconButton icon="target" disabled={vessel.track === undefined} />
+        </div>
         {isEditable &&
         <div onClick={() => this.toggleExpand()} style={{ position: 'relative' }}>
           <ExpandableIconButton activated={this.state.expanded === true} >

--- a/app/src/vessels/containers/Vessel.js
+++ b/app/src/vessels/containers/Vessel.js
@@ -2,12 +2,11 @@ import { connect } from 'react-redux';
 import Vessel from 'vessels/components/Vessel';
 import {
   togglePinnedVesselVisibility,
-  showPinnedVesselDetails,
+  togglePinnedVesselDetails,
   toggleVesselPin,
   setPinnedVesselColor,
   targetVessel
 } from 'vesselInfo/vesselInfoActions';
-import { addVesselToRecentVesselList } from 'recentVessels/recentVesselsActions';
 
 const mapStateToProps = state => ({
   currentlyShownVessel: state.vesselInfo.currentlyShownVessel
@@ -17,9 +16,8 @@ const mapDispatchToProps = dispatch => ({
   toggle(seriesgroup) {
     dispatch(togglePinnedVesselVisibility(seriesgroup));
   },
-  showVesselDetails: (seriesgroup, label, tilesetId) => {
-    dispatch(addVesselToRecentVesselList(seriesgroup, label, tilesetId));
-    dispatch(showPinnedVesselDetails(tilesetId, seriesgroup));
+  togglePinnedVesselDetails: (seriesgroup, label, tilesetId) => {
+    dispatch(togglePinnedVesselDetails(seriesgroup, label, tilesetId));
   },
   delete: (seriesgroup) => {
     dispatch(toggleVesselPin(seriesgroup));

--- a/app/src/vessels/containers/Vessel.js
+++ b/app/src/vessels/containers/Vessel.js
@@ -4,7 +4,8 @@ import {
   togglePinnedVesselVisibility,
   showPinnedVesselDetails,
   toggleVesselPin,
-  setPinnedVesselColor
+  setPinnedVesselColor,
+  targetVessel
 } from 'vesselInfo/vesselInfoActions';
 import { addVesselToRecentVesselList } from 'recentVessels/recentVesselsActions';
 
@@ -25,6 +26,9 @@ const mapDispatchToProps = dispatch => ({
   },
   setColor(seriesgroup, color) {
     dispatch(setPinnedVesselColor(seriesgroup, color));
+  },
+  targetVessel: (seriesgroup) => {
+    dispatch(targetVessel(seriesgroup));
   }
 });
 

--- a/app/src/workspace/workspaceActions.js
+++ b/app/src/workspace/workspaceActions.js
@@ -237,7 +237,12 @@ function dispatchActions(workspaceData, dispatch, getState) {
       if (workspaceData.shownVessel.seriesgroup === undefined) {
         console.warn(`attempting to load vessel on tileset ${workspaceData.shownVessel.tilesetId} with no seriesgroup`);
       } else {
-        dispatch(addVessel(workspaceData.shownVessel.tilesetId, workspaceData.shownVessel.seriesgroup, workspaceData.shownVessel.series));
+        const { tilesetId, seriesgroup, series } = workspaceData.shownVessel;
+        dispatch(addVessel({
+          tilesetId,
+          seriesgroup,
+          series
+        }));
       }
     }
     // Mapbox branch compatibility: track layers should have color, not hue

--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -15,7 +15,7 @@ $offset-panel-control: 20px;
 $menu-left-padding: 30px;
 $menu-right-padding: 30px;
 $menu-mobile-left-padding: 20px;
-$menu-mobile-right-padding: 30px;
+$menu-mobile-right-padding: 20px;
 
 $header-height-mobile: 80px;
 $header-height: 66px;

--- a/app/styles/_settings.scss
+++ b/app/styles/_settings.scss
@@ -13,7 +13,7 @@ $offset-panel-control-mobile: 108px;
 $offset-panel-control: 20px;
 
 $menu-left-padding: 30px;
-$menu-right-padding: 40px;
+$menu-right-padding: 30px;
 $menu-mobile-left-padding: 20px;
 $menu-mobile-right-padding: 30px;
 

--- a/app/styles/components/info-panel.scss
+++ b/app/styles/components/info-panel.scss
@@ -187,18 +187,14 @@
     }
   }
 
-  .pinIcon {
-    fill: $color-3;
+  .actionIcons {
     position: absolute;
     right: 86px;
+    display: flex;
+    flex-direction: column;
 
     @media #{$mq-tablet} {
-      right: 30px;
-      margin-top: 5px;
-    }
-
-    &._pinned {
-      fill: #fff;
+      right: 16px;
     }
   }
 

--- a/app/styles/components/map/item-list.scss
+++ b/app/styles/components/map/item-list.scss
@@ -50,12 +50,11 @@
   width: 100%;
   @media #{$mq-tablet} {
     padding-left: $menu-left-padding;
-    padding-right: 36px;
+    padding-right: $menu-right-padding;
 
     &._alignLeft {
       padding-right: 4px;
     }
-
   }
 
   &._noPadding {

--- a/app/styles/components/map/item-list.scss
+++ b/app/styles/components/map/item-list.scss
@@ -45,7 +45,7 @@
   display: flex;
   flex-wrap: wrap;
   padding-left: $menu-mobile-left-padding;
-  padding-right: 20px;
+  padding-right: $menu-mobile-right-padding;
   position: relative;
   width: 100%;
   @media #{$mq-tablet} {

--- a/app/styles/components/shared/accordion.scss
+++ b/app/styles/components/shared/accordion.scss
@@ -12,7 +12,7 @@
     padding-left: $menu-mobile-left-padding;
 
     @media #{$mq-tablet} {
-      padding-right: 45px;
+      padding-right: $menu-right-padding;
       padding-left: $menu-left-padding;
     }
 


### PR DESCRIPTION
This implements https://github.com/GlobalFishingWatch/map-client/issues/930

- Added buttons to fit the viewport and timebar to vessel tracks (both in pinned vessels list and vessail details panel)
- Removed automatic fit to viewport and timebar when clicking on a vessel search result (can now be done by explicitely clicking the button)
- Clicking the (i) vessel button again now hides vessel details
- Harmonisation of icons

![fishing-target](https://user-images.githubusercontent.com/1583415/45038026-ab2cf780-b060-11e8-872b-66d41029429e.gif)
