### PR TITLE
Adds support for line and point custom layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 3.0.6
+- Added support for line and point custom layers
+
+## 3.0.5
+- Bigger tolerance radius when clicking on activity layers
+
+## 3.0.4
+- Fixed issue when adding more than one filter group
+
+## 3.0.3
+- Fixed styles loading issue
+
+## 3.0.2
+- Fixed custom layer loading from workspace
+
+## 3.0.1
+- Fixed displaying activity layers when resizing viewport
+
 ## 3.0.0
 - Allow custom Mapbox GL JSON style in workspaces - [#943](https://github.com/GlobalFishingWatch/map-client/pull/943)
 - Deeper zoom levels up to 14, even when activity layer tiles are not visible - [#942](https://github.com/GlobalFishingWatch/map-client/pull/942)

--- a/app/src/util/getMainGeomType.js
+++ b/app/src/util/getMainGeomType.js
@@ -1,0 +1,42 @@
+// This utility looks at GeoJSON features and returns the predominant geometry type
+
+const TYPES = [
+  { gl: 'line', geoJSON: ['LineString', 'MultiLineString'] },
+  { gl: 'fill', geoJSON: ['Polygon', 'MultiPolygon'] },
+  { gl: 'circle', geoJSON: ['Point', 'MultiPoint'] }
+];
+
+export default (geoJSON) => {
+  // collect all geoJSON geom types
+  const allGeoJSONTypes = geoJSON.features.map((feature) => {
+    const geom = feature.geometry;
+    if (geom === undefined) {
+      return null;
+    }
+    return geom.type;
+  });
+
+  // collect number of geometries by GL geom types
+  const numByGLType = TYPES.map((type) => {
+    let num = 0;
+    allGeoJSONTypes.forEach((geoJSONType) => {
+      if (type.geoJSON.indexOf(geoJSONType) > -1) {
+        num++;
+      }
+    });
+    return { gl: type.gl, num };
+  });
+
+  // get feature types with the higher count
+  let glType = 'fill';
+  let glTypeMax = 0;
+  numByGLType.forEach((t) => {
+    if (t.num > glTypeMax) {
+      glType = t.gl;
+      glTypeMax = t.num;
+    }
+  });
+
+  return glType;
+
+};


### PR DESCRIPTION
Uploading a custom layer, the client will now look at the predominant GeoJSON feature type, and render the GL layer accordingly. Supports:
- polygon (`fill`)
- lines (`line`)
- points (`circle`) 

Workspace `udw-v2-12a70761-3661-44ad-90a9-981418e7b857` shows an example of the 3 types together:

![screenshot 2018-11-06 at 12 00 40](https://user-images.githubusercontent.com/1583415/48060941-b7971300-e1bd-11e8-9e08-d9f6fcc62e6a.png)

Fixes https://github.com/GlobalFishingWatch/map-client/issues/989

Custom layers could be further improved with
<a href="https://github.com/GlobalFishingWatch/map-client/issues/991">Support different geometry types within a single custom layer</a> 
<a href="https://github.com/GlobalFishingWatch/map-client/issues/992">Support for labels in custom layers</a> 