### PR TITLE
UTC timestamp display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+### Changed
+- Fixed timestamp displays to be in UTC rather than local times (in VIIRS info, hover tooltips, and encounters panel) ([#999](https://github.com/GlobalFishingWatch/map-client/issues/999))
+
 ## 3.0.6
 - Added support for line and point custom layers
 

--- a/app/src/encounters/components/EncountersInfo.jsx
+++ b/app/src/encounters/components/EncountersInfo.jsx
@@ -34,8 +34,9 @@ class EncountersInfo extends Component {
       </div>)
     );
 
-    const date = (encountersInfo.datetime === undefined) ? '-' : moment(encountersInfo.datetime).format(FORMAT_DATE);
-    const time = (encountersInfo.datetime === undefined) ? '-' : moment(encountersInfo.datetime).format(FORMAT_TIME);
+    const m = moment(encountersInfo.datetime).utc();
+    const date = (encountersInfo.datetime === undefined) ? '-' : m.format(FORMAT_DATE);
+    const time = (encountersInfo.datetime === undefined) ? '-' : m.format(`${FORMAT_TIME} UTC`);
     const duration = (encountersInfo.duration === undefined) ? '-' : moment.duration(encountersInfo.duration).humanize();
     return (
       <div className={infoPanelStyles.info}>

--- a/app/src/map/mapInteractionActions.js
+++ b/app/src/map/mapInteractionActions.js
@@ -113,7 +113,7 @@ export const mapHover = (latitude, longitude, features) => (dispatch, getState) 
       const foundVessel = foundVessels[0];
       if (foundVessel.timeIndex) {
         const date = new Date(convert.getTimestampFromOffsetedtTimeAtPrecision(foundVessel.timeIndex));
-        featureTitle = moment(date).format(FORMAT_DATE);
+        featureTitle = moment(date).utc().format(FORMAT_DATE);
       }
     } else {
       const numVessels = (foundVessels === undefined) ? 'multiple' : foundVessels.length;

--- a/app/src/recentVessels/components/RecentVesselItem.jsx
+++ b/app/src/recentVessels/components/RecentVesselItem.jsx
@@ -7,6 +7,7 @@ import PinIcon from '-!babel-loader!svg-react-loader!assets/icons/pin.svg?name=P
 import classnames from 'classnames';
 import RecentVesselStyles from 'styles/recentVessels/recent-vessels.scss';
 import moment from 'moment';
+import { FORMAT_DATE, FORMAT_TIME } from 'config';
 
 class RecentVesselItem extends Component {
 
@@ -30,7 +31,7 @@ class RecentVesselItem extends Component {
 
     let timestamp = 'no date';
     if (this.props.vesselInfo.timestamp !== undefined) {
-      timestamp = moment(this.props.vesselInfo.timestamp).format('DD/MM/YYYY HH:MM');
+      timestamp = moment(this.props.vesselInfo.timestamp).format(`${FORMAT_DATE} ${FORMAT_TIME}`);
     }
     const highlightName = this.highlightWord(this.props.searchTerm, title);
 

--- a/app/src/vesselInfo/components/VesselInfoDetails.jsx
+++ b/app/src/vesselInfo/components/VesselInfoDetails.jsx
@@ -82,7 +82,7 @@ class VesselInfoDetails extends Component {
           break;
         case 'datetime': {
           const humanizedDate = vesselInfo[field.id] ?
-            moment(vesselInfo[field.id]).format(`${FORMAT_DATE} ${FORMAT_TIME}`) :
+            moment(vesselInfo[field.id]).utc().format(`${FORMAT_DATE} ${FORMAT_TIME} UTC`) :
             null;
           renderedFieldList.push(<div key={field.id} className={infoPanelStyles.rowInfo}>
             <span className={infoPanelStyles.key}>{field.display}</span>


### PR DESCRIPTION
Fixed timestamp displays to be in UTC rather than local time (in VIIRS info, hover tooltips, and encounters panel). Also added 'UTC' in plain text to display datetimes to remove any potential ambiguity.

This can be merged to master.

<img width="157" alt="screenshot 2018-12-15 at 10 48 41" src="https://user-images.githubusercontent.com/1583415/50041633-33f00200-0058-11e9-9eb2-c2095bc7345c.png">
<img width="321" alt="screenshot 2018-12-15 at 10 49 37" src="https://user-images.githubusercontent.com/1583415/50041634-34889880-0058-11e9-8d0e-b38200e7a49f.png">
<img width="508" alt="screenshot 2018-12-15 at 10 50 08" src="https://user-images.githubusercontent.com/1583415/50041635-34889880-0058-11e9-8595-aed6664b14ab.png">

Closes https://github.com/GlobalFishingWatch/map-client/issues/999