### PR TITLE
Fixed loading vessel twice from workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Fixed
+- Fixed an issue where a vessel track and info would be loaded twice when having it both pinned and displayed in a given workspace ([#1006](https://github.com/GlobalFishingWatch/map-client/issues/1006))
+
 ## 3.1.0
 
 ### Added

--- a/app/src/activityLayers/components/ActivityLayers.jsx
+++ b/app/src/activityLayers/components/ActivityLayers.jsx
@@ -329,8 +329,6 @@ class ActivityLayers extends React.Component {
           endIndex={endIndex}
           timelineOverExtentIndexes={timelineOverExtentIndexes}
           rootStage={this.stage}
-          viewportLeft={leftWorldScaled}
-          viewportRight={rightWorldScaled}
           highlightedTrack={highlightedTrack}
         />
       }

--- a/app/src/activityLayers/components/TracksLayer.jsx
+++ b/app/src/activityLayers/components/TracksLayer.jsx
@@ -98,7 +98,7 @@ class TracksLayer extends React.Component {
     data, startIndex, endIndex, series, drawFishingCircles,
     fishingCirclesRadius, color, lineThickness, lineOpacity, worldOffset = 0
   }) {
-    const { viewport, viewportLeft } = this.props;
+    const { viewport } = this.props;
 
     let n = 0;
     let prevSeries;
@@ -142,7 +142,9 @@ class TracksLayer extends React.Component {
 
         // more than a ½ world of distance between two points = crossing the dateline
         if (prevWorldX && Math.abs(worldX - prevWorldX) > 256) {
+          // worldOffset === 0 -> this is the first time drawTrack is called
           if (worldOffset === 0) {
+            // set a flag to call drawTrack again at the end of the loop
             duplicateWorld = true;
           }
 
@@ -196,18 +198,19 @@ class TracksLayer extends React.Component {
     }
 
     if (duplicateWorld === true) {
-      const nextWorldOffset = (viewportLeft > 0) ? 512 : -512;
-      this._drawTrack({
-        worldOffset: nextWorldOffset,
-        data,
-        startIndex,
-        endIndex,
-        series,
-        drawFishingCircles,
-        fishingCirclesRadius,
-        color,
-        lineThickness,
-        lineOpacity
+      [-512, 512].forEach((offset) => {
+        this._drawTrack({
+          worldOffset: offset,
+          data,
+          startIndex,
+          endIndex,
+          series,
+          drawFishingCircles,
+          fishingCirclesRadius,
+          color,
+          lineThickness,
+          lineOpacity
+        });
       });
     }
     return n;
@@ -226,8 +229,7 @@ TracksLayer.propTypes = {
   endIndex: PropTypes.number,
   timelineOverExtentIndexes: PropTypes.array,
   tracks: PropTypes.array,
-  highlightedTrack: PropTypes.number,
-  viewportLeft: PropTypes.number
+  highlightedTrack: PropTypes.number
 };
 
 export default TracksLayer;

--- a/app/src/vesselInfo/vesselInfoActions.js
+++ b/app/src/vesselInfo/vesselInfoActions.js
@@ -183,12 +183,13 @@ export function getVesselTrack({ tilesetId, seriesgroup, series }) {
 
         const vectorArray = addTracksPointsRenderingData(rawTrackData);
         const bounds = getTrackBounds(rawTrackData, series);
+        const playbackData = getTracksPlaybackData(vectorArray);
 
         dispatch({
           type: SET_VESSEL_TRACK,
           payload: {
             seriesgroup,
-            data: getTracksPlaybackData(vectorArray),
+            data: playbackData,
             series: uniq(rawTrackData.series),
             geoBounds: bounds.geo,
             timelineBounds: bounds.time,
@@ -261,7 +262,7 @@ export const applyFleetOverrides = () => (dispatch, getState) => {
   });
 };
 
-export function setPinnedVessels(pinnedVessels) {
+export function setPinnedVessels(pinnedVessels, shownVessel) {
   return (dispatch, getState) => {
     const state = getState();
     const options = {
@@ -324,6 +325,17 @@ export function setPinnedVessels(pinnedVessels) {
           getVesselName(pinnedVessel, layer.header.info.fields),
           pinnedVessel.tilesetId
         ));
+
+        if (shownVessel.seriesgroup === pinnedVessel.seriesgroup) {
+          dispatch({
+            type: SET_VESSEL_DETAILS,
+            payload: {
+              vesselData: data,
+              layer
+            }
+          });
+          dispatch(showVesselDetails(pinnedVessel.tilesetId, pinnedVessel.seriesgroup));
+        }
       };
       request.send(null);
     });

--- a/app/src/workspace/workspaceActions.js
+++ b/app/src/workspace/workspaceActions.js
@@ -237,11 +237,15 @@ function dispatchActions(workspaceData, dispatch, getState) {
         console.warn(`attempting to load vessel on tileset ${workspaceData.shownVessel.tilesetId} with no seriesgroup`);
       } else {
         const { tilesetId, seriesgroup, series } = workspaceData.shownVessel;
-        dispatch(addVessel({
-          tilesetId,
-          seriesgroup,
-          series
-        }));
+
+        // only add vessel if it won't be loaded by loading pinned vessels mechanism later
+        if (!workspaceData.pinnedVessels.map(v => v.seriesgroup).includes(seriesgroup)) {
+          dispatch(addVessel({
+            tilesetId,
+            seriesgroup,
+            series
+          }));
+        }
       }
     }
     // Mapbox branch compatibility: track layers should have color, not hue
@@ -252,7 +256,7 @@ function dispatchActions(workspaceData, dispatch, getState) {
       delete pinnedVessel.hue;
     });
 
-    dispatch(setPinnedVessels(workspaceData.pinnedVessels));
+    dispatch(setPinnedVessels(workspaceData.pinnedVessels, workspaceData.shownVessel));
     dispatch(setFleetsFromWorkspace(workspaceData.fleets));
 
     if (workspaceData.encounters !== null && workspaceData.encounters !== undefined &&


### PR DESCRIPTION
Fixes an issue where a vessel track and info would be loaded twice when having it both pinned and displayed in a given workspace.
Seems to fix #1006 