### PR TITLE
use canonical url and https to load meta

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,16 +20,19 @@
     <!-- http://stackoverflow.com/questions/4687698/mulitple-apple-touch-startup-image-resolutions-for-ios-web-app-esp-for-ipad -->
     <!-- <link rel="apple-touch-startup-image" href=""> -->
 
+    <!-- Avoid duplicates in google analytics -->
+    <link rel="canonical" href="https://globalfishingwatch.org/map/" />
+
     <!-- Schema.org markup for Google+ -->
     <meta itemprop="name" content="Global Fishing Watch | Sustainability through Transparency" />
     <meta
       itemprop="description"
       content="Through our free and open data transparency platform, Global Fishing Watch enables research and innovation in support of ocean sustainability."
     />
-    <meta itemprop="image" content="http://globalfishingwatch.org/apple-touch-icon.png" />
+    <meta itemprop="image" content="https://globalfishingwatch.org/apple-touch-icon.png" />
 
     <!-- Open Graph data -->
-    <meta property="og:url" content="http://globalfishingwatch.org/" />
+    <meta property="og:url" content="https://globalfishingwatch.org/" />
     <meta property="og:type" content="website" />
     <meta
       property="og:site_name"
@@ -40,10 +43,10 @@
       property="og:description"
       content="Through our free and open data transparency platform, Global Fishing Watch enables research and innovation in support of ocean sustainability."
     />
-    <meta property="og:image" content="http://globalfishingwatch.org/map/social_image.jpg" />
+    <meta property="og:image" content="https://globalfishingwatch.org/map/social_image.jpg" />
     <meta
       property="og:image:secure_url"
-      content="http://globalfishingwatch.org/map/social_image.jpg"
+      content="https://globalfishingwatch.org/map/social_image.jpg"
     />
     <meta property="og:image:type" content="image/jpg" />
     <meta property="og:image:width" content="400" />
@@ -64,7 +67,7 @@
       name="twitter:description"
       content="Through our free and open data transparency platform, Global Fishing Watch enables research and innovation in support of ocean sustainability."
     />
-    <meta name="twitter:image" content="http://globalfishingwatch.org/map/social_image.jpg" />
+    <meta name="twitter:image" content="https://globalfishingwatch.org/map/social_image.jpg" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
Mark `map` as canonical URL to avoid duplicates for different workspaces in google results.