### PR TITLE
Encounters mapboxgl

### DIFF
--- a/bin/retrieve-workspace.js
+++ b/bin/retrieve-workspace.js
@@ -30,7 +30,7 @@ https
         const workspaceJSON = JSON.parse(data)
         let workspace = JSON.stringify(workspaceJSON, null, 2)
         workspace = `
-// AUTOMATICALLY RETRIEVED FROM ENV VARIABLES. DO NOT EDIT.
+// AUTOMATICALLY RETRIEVED FROM ENV VARIABLES. WILL BE OVERWRITTEN AT NEXT NPM INSTALL.
 const defaultWorkspace = ${workspace};
 export default defaultWorkspace;
       `

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": ".",
   "dependencies": {
-    "@globalfishingwatch/map-components": "1.8.0",
+    "@globalfishingwatch/map-components": "1.8.1",
     "@globalfishingwatch/map-convert": "github:GlobalFishingWatch/map-convert",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/vector-tile": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": ".",
   "dependencies": {
-    "@globalfishingwatch/map-components": "1.7.3",
+    "@globalfishingwatch/map-components": "1.8.0",
     "@globalfishingwatch/map-convert": "github:GlobalFishingWatch/map-convert",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/vector-tile": "^1.3.0",

--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -31,6 +31,8 @@ export const LAYER_TYPES_DISPLAYED_IN_PANELS = [
   LAYER_TYPES.Encounters,
 ]
 
+export const ENCOUNTERS_AIS = 'encounters_ais'
+
 export const LAYER_TYPES_MAPBOX_GL = [LAYER_TYPES.Custom, LAYER_TYPES.Static]
 
 export const HEADERLESS_LAYERS = ['shark-points', 'shark-tracks']

--- a/src/app/encounters/encountersActions.js
+++ b/src/app/encounters/encountersActions.js
@@ -28,7 +28,7 @@ export function clearEncountersInfo() {
 export function setEncountersInfo(seriesgroup, tilesetId) {
   return (dispatch, getState) => {
     const workspaceLayers = getState().layers.workspaceLayers
-    const encounterLayer = workspaceLayers.find((l) => l.id === tilesetId)
+    const encounterLayer = workspaceLayers.find((l) => l.tilesetId === tilesetId || l.id === tilesetId)
 
     // dispatch(highlightClickedVessel(seriesgroup, encounterLayer.id)); TODO MAP MODULE
 

--- a/src/app/encounters/encountersActions.js
+++ b/src/app/encounters/encountersActions.js
@@ -28,7 +28,9 @@ export function clearEncountersInfo() {
 export function setEncountersInfo(seriesgroup, tilesetId) {
   return (dispatch, getState) => {
     const workspaceLayers = getState().layers.workspaceLayers
-    const encounterLayer = workspaceLayers.find((l) => l.tilesetId === tilesetId || l.id === tilesetId)
+    const encounterLayer = workspaceLayers.find(
+      (l) => l.tilesetId === tilesetId || l.id === tilesetId
+    )
 
     // dispatch(highlightClickedVessel(seriesgroup, encounterLayer.id)); TODO MAP MODULE
 

--- a/src/app/encounters/encountersActions.js
+++ b/src/app/encounters/encountersActions.js
@@ -28,7 +28,7 @@ export function clearEncountersInfo() {
 export function setEncountersInfo(seriesgroup, tilesetId) {
   return (dispatch, getState) => {
     const workspaceLayers = getState().layers.workspaceLayers
-    const encounterLayer = workspaceLayers.find((l) => l.tilesetId === tilesetId)
+    const encounterLayer = workspaceLayers.find((l) => l.id === tilesetId)
 
     // dispatch(highlightClickedVessel(seriesgroup, encounterLayer.id)); TODO MAP MODULE
 

--- a/src/app/layers/layersActions.js
+++ b/src/app/layers/layersActions.js
@@ -36,8 +36,10 @@ function loadLayerHeader(tilesetUrl, token) {
     headers.Authorization = `Bearer ${token}`
   }
 
+  const headerUrl = `${tilesetUrl}/header`
+
   return new Promise((resolve) => {
-    fetch(`${tilesetUrl}/header`, {
+    fetch(headerUrl, {
       method: 'GET',
       headers,
     })
@@ -177,7 +179,11 @@ export function initLayers(workspaceLayers, libraryLayers) {
     // get header promises
     const headersPromises = []
     workspaceLayers
-      .filter((l) => LAYER_TYPES_WITH_HEADER.includes(l.type) && l.added === true)
+      .filter(
+        (l) =>
+          (l.id === 'encounters_ais' || LAYER_TYPES_WITH_HEADER.includes(l.type)) &&
+          l.added === true
+      )
       .forEach((heatmapLayer) => {
         if (HEADERLESS_LAYERS.includes(heatmapLayer.tilesetId)) {
           // headerless layers are considered temporalExtents-less too

--- a/src/app/layers/layersActions.js
+++ b/src/app/layers/layersActions.js
@@ -7,6 +7,7 @@ import {
   HEADERLESS_LAYERS,
   TEMPORAL_EXTENTLESS,
   CUSTOM_LAYERS_SUBTYPES,
+  ENCOUNTERS_AIS,
 } from 'app/constants'
 import { SET_OVERALL_TIMELINE_DATES } from 'app/filters/filtersActions'
 import { refreshFlagFiltersLayers } from 'app/filters/filterGroupsActions'
@@ -181,8 +182,7 @@ export function initLayers(workspaceLayers, libraryLayers) {
     workspaceLayers
       .filter(
         (l) =>
-          (l.id === 'encounters_ais' || LAYER_TYPES_WITH_HEADER.includes(l.type)) &&
-          l.added === true
+          (l.id === ENCOUNTERS_AIS || LAYER_TYPES_WITH_HEADER.includes(l.type)) && l.added === true
       )
       .forEach((heatmapLayer) => {
         if (HEADERLESS_LAYERS.includes(heatmapLayer.tilesetId)) {

--- a/src/app/map/components/HoverPopup.jsx
+++ b/src/app/map/components/HoverPopup.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import classnames from 'classnames'
 import convert from '@globalfishingwatch/map-convert'
-import { LAYER_TYPES } from 'app/constants'
+import { LAYER_TYPES, ENCOUNTERS_AIS } from 'app/constants'
 import { FORMAT_DATE } from 'app/config'
 import PopupStyles from 'styles/components/map/popup.module.scss'
 import moment from 'moment'
 
 const getPopupData = (event, layerTitle) => {
-  if (event.layer.id === 'encounters_ais') {
+  if (event.layer.id === ENCOUNTERS_AIS) {
     const encounter = event.target.properties
     const date = convert.getTimestampFromOffsetedtTimeAtPrecision(encounter.timeIndex)
     const featureTitle = moment(date)

--- a/src/app/map/components/HoverPopup.jsx
+++ b/src/app/map/components/HoverPopup.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import convert from '@globalfishingwatch/map-convert'
 import { LAYER_TYPES, ENCOUNTERS_AIS } from 'app/constants'
@@ -57,6 +58,21 @@ const HoverPopup = (props) => {
       {popup.layerTitle}: {popup.featureTitle}
     </div>
   )
+}
+
+HoverPopup.propTypes = {
+  event: PropTypes.shape({
+    type: PropTypes.string.isRequired,
+    layer: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }),
+    target: PropTypes.shape({
+      properties: PropTypes.object,
+      objects: PropTypes.array,
+      featureTitle: PropTypes.string,
+    }),
+  }).isRequired,
+  layerTitle: PropTypes.string.isRequired,
 }
 
 export default HoverPopup

--- a/src/app/map/components/HoverPopup.jsx
+++ b/src/app/map/components/HoverPopup.jsx
@@ -7,7 +7,17 @@ import PopupStyles from 'styles/components/map/popup.module.scss'
 import moment from 'moment'
 
 const getPopupData = (event, layerTitle) => {
-  if (event.type === 'static') {
+  if (event.layer.id === 'encounters_ais') {
+    const encounter = event.target.properties
+    const date = convert.getTimestampFromOffsetedtTimeAtPrecision(encounter.timeIndex)
+    const featureTitle = moment(date)
+      .utc()
+      .format(FORMAT_DATE)
+    return {
+      layerTitle,
+      featureTitle,
+    }
+  } else if (event.type === 'static') {
     return {
       layerTitle,
       featureTitle: event.target.featureTitle,

--- a/src/app/map/components/MapWrapper.jsx
+++ b/src/app/map/components/MapWrapper.jsx
@@ -31,7 +31,8 @@ class MapWrapper extends Component {
 
   onClick = (event) => {
     this.props.onMapClick(event)
-    const clickPopupData = event.type === 'static' ? event : null
+    const clickPopupData =
+      event.type === 'static' && event.layer.id !== 'encounters_ais' ? event : null
 
     this.setState({
       clickPopupData,
@@ -46,11 +47,17 @@ class MapWrapper extends Component {
     }
     const { workspaceLayers } = this.props
     const workspaceLayer = workspaceLayers.find((l) => l.id === hoverPopupData.layer.id)
-    return <HoverPopup event={hoverPopupData} layerTitle={workspaceLayer.title} />
+    return (
+      <HoverPopup
+        event={hoverPopupData}
+        layerTitle={workspaceLayer.title || workspaceLayer.label}
+      />
+    )
   }
 
   onHover = (event) => {
     const hoverPopupData = event.type !== null ? event : null
+
     this.props.onMapHover(event)
     this.setState({
       hoverPopupData,

--- a/src/app/map/components/MapWrapper.jsx
+++ b/src/app/map/components/MapWrapper.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import StaticLayerPopup from 'app/map/components/StaticLayerPopup'
 import HoverPopup from 'app/map/components/HoverPopup'
 import Loader from 'app/mapPanels/leftControlPanel/components/Loader'
+import { ENCOUNTERS_AIS } from 'app/constants'
 
 const MapModule = React.lazy(() => import('@globalfishingwatch/map-components/components/map'))
 
@@ -32,7 +33,7 @@ class MapWrapper extends Component {
   onClick = (event) => {
     this.props.onMapClick(event)
     const clickPopupData =
-      event.type === 'static' && event.layer.id !== 'encounters_ais' ? event : null
+      event.type === 'static' && event.layer.id !== ENCOUNTERS_AIS ? event : null
 
     this.setState({
       clickPopupData,

--- a/src/app/map/components/MapWrapper.jsx
+++ b/src/app/map/components/MapWrapper.jsx
@@ -124,6 +124,7 @@ class MapWrapper extends Component {
   }
 }
 
+/* eslint-disable react/require-default-props  */
 MapWrapper.propTypes = {
   // sent to MapModule
   onViewportChange: PropTypes.func,

--- a/src/app/map/containers/MapWrapper.js
+++ b/src/app/map/containers/MapWrapper.js
@@ -77,7 +77,7 @@ const getHeatmapLayers = createSelector(
     // for now interactive is set for all heatmap layers
     // (ie disable all layers if report is triggered)
     const interactive = report.layerId === null
-    return layers
+    const heatmapLayers = layers
       .filter((layer) => layer.type === LAYER_TYPES.Heatmap && layer.added === true)
       .map((layer) => {
         const filters = layerFilters[layer.id] || []
@@ -95,16 +95,17 @@ const getHeatmapLayers = createSelector(
         }
         return layerParams
       })
+    console.log(heatmapLayers)
+    return heatmapLayers
   }
 )
 
 const getStaticLayers = createSelector(
   [getLayers, getReport],
-  (layers, report) =>
-    layers
+  (layers, report) => {
+    const staticLayers = layers
       .filter((layer) => LAYER_TYPES_MAPBOX_GL.indexOf(layer.type) > -1)
       .map((layer) => {
-        // TODO replace with selectedFeatures
         const selectedFeatures =
           report.layerId === layer.id
             ? {
@@ -112,6 +113,10 @@ const getStaticLayers = createSelector(
                 values: report.polygonsIds,
               }
             : null
+        let url
+        if (layer.header && layer.header.endpoints) {
+          url = layer.header.endpoints.tiles.replace(/\{\{/g, '{').replace(/\}\}/g, '}')
+        }
         const layerParams = {
           id: layer.id,
           visible: layer.visible,
@@ -123,13 +128,15 @@ const getStaticLayers = createSelector(
           // -- needed for custom layers
           isCustom: layer.isCustom,
           subtype: layer.subtype,
-          url: layer.url,
+          url,
           data: layer.data,
           // -- needed for workspace GL layers
           gl: layer.gl,
         }
         return layerParams
       })
+    return staticLayers
+  }
 )
 
 const getBasemapLayers = createSelector(
@@ -191,7 +198,6 @@ const mapDispatchToProps = (dispatch) => ({
       const target = event.target
       if (target.isCluster === true) {
         dispatch(trackMapClicked(event.latitude, event.longitude, 'cluster'))
-        // dispatch(hideVesselsInfoPanel());
       } else if (event.layer.subtype === LAYER_TYPES.Encounters) {
         dispatch(
           setEncountersInfo(
@@ -212,7 +218,11 @@ const mapDispatchToProps = (dispatch) => ({
         )
       }
     } else if (event.type === 'static') {
-      dispatch(setCurrentSelectedPolygon(event.target.properties))
+      if (event.layer.id === 'encounters_ais') {
+        dispatch(setEncountersInfo(event.target.properties.id, 'encounters_ais'))
+      } else {
+        dispatch(setCurrentSelectedPolygon(event.target.properties))
+      }
     }
   },
   toggleCurrentReportPolygon: () => {

--- a/src/app/map/containers/MapWrapper.js
+++ b/src/app/map/containers/MapWrapper.js
@@ -6,7 +6,7 @@ import { clearVesselInfo, addVessel } from 'app/vesselInfo/vesselInfoActions'
 import { setEncountersInfo, clearEncountersInfo } from 'app/encounters/encountersActions'
 import { trackMapClicked } from 'app/analytics/analyticsActions'
 import { toggleCurrentReportPolygon, setCurrentSelectedPolygon } from 'app/report/reportActions'
-import { LAYER_TYPES, LAYER_TYPES_MAPBOX_GL } from 'app/constants'
+import { LAYER_TYPES, LAYER_TYPES_MAPBOX_GL, ENCOUNTERS_AIS } from 'app/constants'
 import MapWrapper from 'app/map/components/MapWrapper'
 
 const getVessels = (state) => state.vesselInfo.vessels
@@ -95,7 +95,6 @@ const getHeatmapLayers = createSelector(
         }
         return layerParams
       })
-    console.log(heatmapLayers)
     return heatmapLayers
   }
 )
@@ -218,8 +217,8 @@ const mapDispatchToProps = (dispatch) => ({
         )
       }
     } else if (event.type === 'static') {
-      if (event.layer.id === 'encounters_ais') {
-        dispatch(setEncountersInfo(event.target.properties.id, 'encounters_ais'))
+      if (event.layer.id === ENCOUNTERS_AIS) {
+        dispatch(setEncountersInfo(event.target.properties.id, ENCOUNTERS_AIS))
       } else {
         dispatch(setCurrentSelectedPolygon(event.target.properties))
       }


### PR DESCRIPTION
Adds support for a Mapbx GL powered encounters layer.
Needs https://github.com/GlobalFishingWatch/map-components/pull/56

Although this is experimental, I'd like to merge as it fixes several issues.

The workspace layer that needs to be used:
```
        {
          'id': 'encounters_ais',
          'visible': true,
          'interactive': true,
          'color': '#eeff00',
          "url": "https://api-dot-skytruth-pelagos-production.appspot.com/v2/tilesets/gfw-task-673-encounters-v3",
          "type": "CartoDBAnimation",
          "label": "Encounters",
        },
```

We will need to generalize the behaviour created for encounters to all interactive time-series layer based on Mapbox GL:
- loading of headers 
  - needs adding an headerURL field to workspace.json
  - refactor workspace format entirely now? (https://github.com/GlobalFishingWatch/map-client/issues/871)
- refactor interaction.actions
  - interaction priority should not always be given to heatmap 
  - object returned to callback needs to be more useful
- stop using the `type` field on workspace layer to determine in which Panel the layer will go 