### PR TITLE
Don't overlap language selector with loading spinner

### DIFF
--- a/documentation/env_variables.md
+++ b/documentation/env_variables.md
@@ -32,7 +32,7 @@ Enable usage of the "Subscription" feature.
 
 #### REACT_APP_FEATURE_TRANSLATIONS
 
-Enable to include translations engine
+Enable to include translations engine (bablic) and language selctor.
 
 ## Boolean flags
 

--- a/src/app/mapPanels/leftControlPanel/components/LeftControlPanel.jsx
+++ b/src/app/mapPanels/leftControlPanel/components/LeftControlPanel.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-import Loader from 'app/mapPanels/leftControlPanel/containers/Loader'
 import ZoomControls from 'app/mapPanels/leftControlPanel/components/ZoomControls'
+import LanguageSelector from 'app/components/Shared/LanguageSelector'
+import Loader from 'app/mapPanels/leftControlPanel/containers/Loader'
 import LeftControlPanelStyles from 'app/mapPanels/leftControlPanel/components/leftControlPanel.module.scss'
 
 class LeftControlPanel extends Component {
@@ -22,14 +23,7 @@ class LeftControlPanel extends Component {
         this.props.userPermissions.indexOf('shareWorkspace') !== -1)
 
     return (
-      <div>
-        <div
-          className={classnames(LeftControlPanelStyles.mapLoader, {
-            [LeftControlPanelStyles._isEmbedded]: isEmbedded,
-          })}
-        >
-          <Loader tiny />
-        </div>
+      <div className={LeftControlPanelStyles.container}>
         {mouseLatLon !== null && (
           <div className={LeftControlPanelStyles.latlon}>
             {mouseLatLon.latitude.toFixed(4)}, {mouseLatLon.longitude.toFixed(4)}
@@ -42,6 +36,14 @@ class LeftControlPanel extends Component {
           canZoomOut={this.props.canZoomOut}
           changeZoomLevel={this.changeZoomLevel}
         />
+        <LanguageSelector />
+        <div
+          className={classnames(LeftControlPanelStyles.mapLoader, {
+            [LeftControlPanelStyles._isEmbedded]: isEmbedded,
+          })}
+        >
+          <Loader tiny />
+        </div>
       </div>
     )
   }

--- a/src/app/mapPanels/leftControlPanel/components/Loader.jsx
+++ b/src/app/mapPanels/leftControlPanel/components/Loader.jsx
@@ -4,7 +4,8 @@ import classnames from 'classnames'
 import LoaderStyles from 'styles/components/loader.module.scss'
 
 export default function Loader({ visible, absolute, tiny }) {
-  const loader = (
+  if (!visible) return null
+  return (
     <div
       className={classnames([
         LoaderStyles.loader,
@@ -26,10 +27,16 @@ export default function Loader({ visible, absolute, tiny }) {
       </div>
     </div>
   )
-  return visible ? loader : false
 }
 
 Loader.propTypes = {
   visible: PropTypes.bool,
   absolute: PropTypes.bool,
+  tiny: PropTypes.bool,
+}
+
+Loader.defaultProps = {
+  visible: false,
+  absolute: false,
+  tiny: false,
 }

--- a/src/app/mapPanels/leftControlPanel/components/ZoomControls.jsx
+++ b/src/app/mapPanels/leftControlPanel/components/ZoomControls.jsx
@@ -3,7 +3,6 @@ import React, { PureComponent } from 'react'
 import classnames from 'classnames'
 import ZoomControlsStyles from 'app/mapPanels/leftControlPanel/components/zoomControls.module.scss'
 import iconStyles from 'styles/icons.module.scss'
-import LanguageSelector from 'app/components/Shared/LanguageSelector'
 import Icon from 'app/components/Shared/Icon'
 import { ReactComponent as ZoomInIcon } from 'assets/icons/zoom-in.svg'
 import { ReactComponent as ZoomOutIcon } from 'assets/icons/zoom-out.svg'
@@ -42,7 +41,6 @@ class ZoomControls extends PureComponent {
             <Icon icon="share" activated />
           </span>
         )}
-        <LanguageSelector />
       </div>
     )
   }

--- a/src/app/mapPanels/leftControlPanel/components/leftControlPanel.module.scss
+++ b/src/app/mapPanels/leftControlPanel/components/leftControlPanel.module.scss
@@ -1,15 +1,19 @@
 @import '../../../../styles/settings';
 
-.mapLoader {
+.container {
   left: 8px;
   position: absolute;
-  top: 160px;
+  top: 144px;
   z-index: 6;
 
   @media #{$mq-tablet} {
     left: 6px;
-    top: 250px;
+    top: 110px;
   }
+}
+
+.mapLoader {
+  z-index: 6;
 
   &._isEmbedded {
     left: 6px;
@@ -31,7 +35,7 @@
     font-weight: bold;
     left: 56px;
     position: absolute;
-    top: 112px;
+    top: 0;
     z-index: 99;
   }
 }

--- a/src/app/mapPanels/leftControlPanel/components/leftControlPanel.module.scss
+++ b/src/app/mapPanels/leftControlPanel/components/leftControlPanel.module.scss
@@ -14,6 +14,7 @@
 
 .mapLoader {
   z-index: 6;
+  margin-top: 2px;
 
   &._isEmbedded {
     left: 6px;

--- a/src/app/mapPanels/leftControlPanel/components/zoomControls.module.scss
+++ b/src/app/mapPanels/leftControlPanel/components/zoomControls.module.scss
@@ -1,14 +1,10 @@
 @import '../../../../styles/settings';
 
-
 .zoomControls {
   display: none;
 
   @media #{$mq-tablet} {
     display: block;
-    left: 6px;
-    position: absolute;
-    top: 112px;
     z-index: 6;
   }
 

--- a/src/styles/components/shared/language-selector.module.scss
+++ b/src/styles/components/shared/language-selector.module.scss
@@ -7,7 +7,6 @@ $height: 44px;
   display: flex;
   width: $width;
   margin-top: 2px;
-  margin-bottom: 2px;
 }
 
 .elementContainer {

--- a/src/styles/components/shared/language-selector.module.scss
+++ b/src/styles/components/shared/language-selector.module.scss
@@ -7,6 +7,7 @@ $height: 44px;
   display: flex;
   width: $width;
   margin-top: 2px;
+  margin-bottom: 2px;
 }
 
 .elementContainer {


### PR DESCRIPTION
Spinner was working properly but sometimes and due its absolute styles it was overlapped by the language selector. This PR fixes it positioning the elements in the same container.

![image](https://user-images.githubusercontent.com/10500650/59857787-f313d580-9379-11e9-8ab9-eb0b7e41522f.png)
