### PR TITLE
Legacy tracks to geojson without timebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": ".",
   "dependencies": {
-    "@globalfishingwatch/map-components": "2.2.16",
+    "@globalfishingwatch/map-components": "^2.7.1",
     "@globalfishingwatch/map-convert": "github:GlobalFishingWatch/map-convert",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/vector-tile": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": ".",
   "dependencies": {
-    "@globalfishingwatch/map-components": "^2.2.12",
+    "@globalfishingwatch/map-components": "2.2.16",
     "@globalfishingwatch/map-convert": "github:GlobalFishingWatch/map-convert",
     "@mapbox/tile-cover": "^3.0.2",
     "@mapbox/vector-tile": "^1.3.0",

--- a/src/app/map/containers/MapWrapper.js
+++ b/src/app/map/containers/MapWrapper.js
@@ -53,7 +53,7 @@ const getTrackFromLayers = (layers, tilesetId, vesselId) => {
   }
 }
 
-const getAllVesselsForTracks = createSelector(
+const getTracks = createSelector(
   [getVessels, getEncounter, getLayers, getHighlightedTrack],
   (vessels, encounter, layers, highlightedTrack) => {
     let tracks = []
@@ -85,8 +85,8 @@ const getAllVesselsForTracks = createSelector(
 )
 
 const getHeatmapLayers = createSelector(
-  [getLayers, getLayerFilters, getAllowInteraction],
-  (layers, layerFilters, allowInteraction) => {
+  [getLayers, getLayerFilters, getAllowInteraction, getTracks],
+  (layers, layerFilters, allowInteraction, tracks) => {
     const heatmapLayers = layers
       .filter((layer) => layer.type === LAYER_TYPES.Heatmap && layer.added === true)
       .map((layer) => {
@@ -96,7 +96,7 @@ const getHeatmapLayers = createSelector(
           tilesetId: layer.tilesetId,
           header: layer.header,
           hue: layer.hue,
-          opacity: layer.opacity,
+          opacity: tracks.length > 0 ? 0.15 : layer.opacity,
           visible: layer.visible,
           filters,
           // for now interactive is set for all heatmap layers
@@ -203,7 +203,7 @@ const mapStateToProps = (state) => ({
   // Forwarded to Map Module
   token: state.user.token,
   viewport: getViewport(state),
-  tracks: getAllVesselsForTracks(state),
+  tracks: getTracks(state),
   heatmapLayers: getHeatmapLayers(state),
   staticLayers: getStaticLayers(state),
   basemapLayers: getBasemapLayers(state),

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,10 +910,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@globalfishingwatch/map-components@^2.2.12":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-2.7.0.tgz#bed492eec69e5a5f87ccc6b4a4e3956d0d2873e5"
-  integrity sha512-4gV/wGgBrBU8ygmKW68WBJkBEDABsEHHLpdIWk7Xo1UQsYCz+yDcvNHQUR85BwIt8RcgOefBat402Xw9eA5MaQ==
+"@globalfishingwatch/map-components@2.2.16":
+  version "2.2.16"
+  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-2.2.16.tgz#d7268afbe544efe2caf5db1154b92584e7f9ce9d"
+  integrity sha512-Sj+bEaj7+j61VCxyFjyeCGC0O2tnnvecSX2O718NMfR0w34Chi53PlgrSmDq9Uz7eUqIv6oFBPcHtzu1YzK7Kg==
   dependencies:
     "@globalfishingwatch/map-convert" "github:GlobalFishingWatch/map-convert"
     "@mapbox/tile-cover" "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,10 +910,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@globalfishingwatch/map-components@2.2.16":
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-2.2.16.tgz#d7268afbe544efe2caf5db1154b92584e7f9ce9d"
-  integrity sha512-Sj+bEaj7+j61VCxyFjyeCGC0O2tnnvecSX2O718NMfR0w34Chi53PlgrSmDq9Uz7eUqIv6oFBPcHtzu1YzK7Kg==
+"@globalfishingwatch/map-components@^2.7.1":
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-2.7.1.tgz#4191d6176e015c8f6f783aca08f7b9639eec9798"
+  integrity sha512-oe7pKp+q6JlU6hiQxLJKqyU+HQVxEnrKE0MA3/H250wrHTzVD9EvIiYSDFcvb2+UwS6VxLOpBzsmu2eSeTKpyw==
   dependencies:
     "@globalfishingwatch/map-convert" "github:GlobalFishingWatch/map-convert"
     "@mapbox/tile-cover" "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,10 +910,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
-"@globalfishingwatch/map-components@^2.2.11":
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-2.2.11.tgz#09ad2bcd02d14386d4a76863a8af177128e9d80d"
-  integrity sha512-Wcc8UX9/IdeETVKphOl9dx793htKA8fiyoeGUfQ+vljK/DIpWPGzRbexgKiPmy4CeZ/IXSn9OKn98DYJy5wLTA==
+"@globalfishingwatch/map-components@^2.2.12":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@globalfishingwatch/map-components/-/map-components-2.7.0.tgz#bed492eec69e5a5f87ccc6b4a4e3956d0d2873e5"
+  integrity sha512-4gV/wGgBrBU8ygmKW68WBJkBEDABsEHHLpdIWk7Xo1UQsYCz+yDcvNHQUR85BwIt8RcgOefBat402Xw9eA5MaQ==
   dependencies:
     "@globalfishingwatch/map-convert" "github:GlobalFishingWatch/map-convert"
     "@mapbox/tile-cover" "^3.0.2"


### PR DESCRIPTION
Ports the heatmap layer feature opacity change from develop.
Uses map-components v2.2.16, which has legacy tracks removed in favour of geojson tracks, but without the new timebar