### PR TITLE
use tooltip field in workspace

### DIFF
--- a/src/app/map/containers/MapWrapper.js
+++ b/src/app/map/containers/MapWrapper.js
@@ -165,12 +165,12 @@ const getBasemapLayers = createSelector(
     })
 )
 
-const getLayersTitles = createSelector(
+const getLayersTooltips = createSelector(
   [getLayers],
   (layers) => {
     const titles = {}
     layers.forEach((layer) => {
-      titles[layer.id] = layer.title
+      titles[layer.id] = layer.tooltip || layer.title
     })
     return titles
   }
@@ -211,7 +211,7 @@ const mapStateToProps = (state) => ({
   loadTemporalExtent: state.filters.timelineOuterExtent,
   highlightTemporalExtent: state.filters.timelineOverExtent,
   // Internal
-  layerTitles: getLayersTitles(state),
+  layerTitles: getLayersTooltips(state),
   report: state.report,
   isCluster,
   rulersEditing: getRulersEditing(state),


### PR DESCRIPTION
To fix https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/21 but not introduce a breaking change updating the title for the fishing effort layer this PR includes a new field in the workspace called `tooltip` with original `title` fallback.

Once this is merged the default workspace in dev and production should be updated to add the line: ```"tooltip": "Apparent fishing effort",```