### PR TITLE
Clusters fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": ".",
   "dependencies": {
     "@globalfishingwatch/api-client": "0.0.15",
-    "@globalfishingwatch/map-components": "3.0.8",
+    "@globalfishingwatch/map-components": "3.0.9",
     "@globalfishingwatch/map-convert": "github:GlobalFishingWatch/map-convert",
     "@mapbox/tile-cover": "3.0.2",
     "@mapbox/vector-tile": "1.3.0",

--- a/src/app/map/components/HoverPopup.jsx
+++ b/src/app/map/components/HoverPopup.jsx
@@ -25,7 +25,7 @@ const getPopupItems = (event, layerTitles) => {
     } else if (feature.layer.group === 'legacyHeatmap') {
       if (feature.isCluster === true) {
         const numVessels = feature.count === -1 ? 'multiple' : feature.count
-        const vesselPlural = feature.count > 1 ? 'objects' : 'object'
+        const vesselPlural = feature.count === -1 || feature.count > 1 ? 'objects' : 'object'
         description = `${numVessels} ${vesselPlural} at this location`
       } else {
         description = convertTimeIndexToDate(feature.properties.timeIndex)


### PR DESCRIPTION
> I'm having a problem with the public map.. I've seen this issue in the past, but I don't remember what we did with this. For some reason when clicking on a cluster (negative value) the client is trying to get vessel info from that negative value instead of saying "There are multiple vessels here, zoom in"... on some cases it works properly, you see the magnifying glass but for some others it does not:

Fixes that ☝️ with this https://github.com/GlobalFishingWatch/map-components/releases/tag/3.0.9